### PR TITLE
chore: eslint rules

### DIFF
--- a/packages/eslint-config-custom/next.js
+++ b/packages/eslint-config-custom/next.js
@@ -39,5 +39,7 @@ module.exports = {
   rules: {
     'import/no-default-export': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/consistent-type-definitions': 'type',
+    'unicorn/filename-case': 'off',
   },
 };


### PR DESCRIPTION
# What does this PR do?

- force ts `type` keyword usage over `interface` (it currently the contrary)
- disable `unicorn/filename-case`