### PR TITLE
chore: enable unicorn-filename-case

### DIFF
--- a/packages/eslint-config-custom/next.js
+++ b/packages/eslint-config-custom/next.js
@@ -40,6 +40,6 @@ module.exports = {
     'import/no-default-export': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-    'unicorn/filename-case': ['error', { case: 'kebabCase', ignore: ['.*\\.tsx$'] }],
+    'unicorn/filename-case': ['error', { case: 'kebabCase', ignore: ['\\.tsx$'] }],
   },
 };

--- a/packages/eslint-config-custom/next.js
+++ b/packages/eslint-config-custom/next.js
@@ -39,7 +39,7 @@ module.exports = {
   rules: {
     'import/no-default-export': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/consistent-type-definitions': 'type',
-    'unicorn/filename-case': 'off',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+    'unicorn/filename-case': ['error', { case: 'kebabCase', ignore: ['.*\\.tsx$'] }],
   },
 };


### PR DESCRIPTION
## Description

- enable eslint unicorn filename case rule except for tsx file
- fix `@typescript-eslint/consistent-type-definitions`

## Additional Notes

I have previously disabled this rule because it was annoying for `tsx` file. But it turn out that it possible to disable it for `tsx` files.
This fix the lint script on every apps (+ template).

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
