### PR TITLE
fix(template): eslint paths alias not working

### DIFF
--- a/packages/eslint-config-custom/next.js
+++ b/packages/eslint-config-custom/next.js
@@ -1,7 +1,3 @@
-const { resolve } = require('node:path');
-
-const project = resolve(process.cwd(), 'tsconfig.json');
-
 /*
  * This is a custom ESLint configuration for use with
  * Next.js apps.
@@ -10,7 +6,6 @@ const project = resolve(process.cwd(), 'tsconfig.json');
  * For more information, see https://github.com/vercel/style-guide
  *
  */
-
 module.exports = {
   extends: [
     '@vercel/style-guide/eslint/node',
@@ -20,24 +15,21 @@ module.exports = {
     '@vercel/style-guide/eslint/next',
     'eslint-config-turbo',
   ].map(require.resolve),
-  parserOptions: {
-    project,
-  },
   globals: {
     React: true,
     JSX: true,
-  },
-  settings: {
-    'import/resolver': {
-      typescript: {
-        project,
-      },
-    },
   },
   ignorePatterns: ['node_modules/', 'dist/'],
   // add rules configurations here
   rules: {
     'import/no-default-export': 'off',
+    'import/no-named-as-default': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        bundledDependencies: false,
+      },
+    ],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     'unicorn/filename-case': ['error', { case: 'kebabCase', ignore: ['\\.tsx$'] }],

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,0 +1,17 @@
+const { resolve } = require('node:path');
+
+const project = resolve(__dirname, './tsconfig.json');
+
+module.exports = {
+  extends: ['custom/next'],
+  parserOptions: {
+    project,
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project,
+      },
+    },
+  },
+};

--- a/template/.eslintrc.json
+++ b/template/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["custom/next"]
-}

--- a/template/package.json
+++ b/template/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^14.0.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
## Description

`eslint-config-custom` next.js is resolving project path at the root of the monorepo instead of the root of the app.
To fix this, the resolving part and properties from the config have been move in the app config (template for now).

Eslint was triggered by import using '@/' (`import/no-extraneous-dependencies`), to fix this BundledDependencies error has been turned off.

> "bundledDependencies" are exactly what their name implies. Dependencies that should be inside your project.

Extra: `import/no-named-as-default` has been turned off as well, otherwise import zod using `import z from "zod"` was triggering an error.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
