### PR TITLE
chore: add elba-api package

### DIFF
--- a/packages/elba-api/.eslintrc.json
+++ b/packages/elba-api/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["custom/library"],
+  "rules": {
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/consistent-type-definitions": ["error", "type"]
+  }
+}

--- a/packages/elba-api/.gitignore
+++ b/packages/elba-api/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/elba-api/.gitignore
+++ b/packages/elba-api/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/packages/elba-api/README.md
+++ b/packages/elba-api/README.md
@@ -1,0 +1,11 @@
+# elba-api
+
+This package contains a minimal mocked elba http API server
+
+You can run the server by running the following command:
+
+```bash
+pnpm start
+```
+
+The server will listen on <http://localhost:3522>

--- a/packages/elba-api/package.json
+++ b/packages/elba-api/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
+    "lint": "eslint server.ts src/**.ts",
+    "lint:fix": "pnpm lint --fix",
     "start": "tsx watch server.ts"
   },
   "dependencies": {
@@ -12,6 +14,8 @@
   },
   "devDependencies": {
     "@hono/node-server": "^1.2.3",
+    "eslint": "^8",
+    "eslint-config-custom": "workspace:*",
     "hono": "^3.10.2",
     "tsconfig": "workspace:*",
     "tsx": "^3.12.2"

--- a/packages/elba-api/package.json
+++ b/packages/elba-api/package.json
@@ -7,12 +7,12 @@
     "start": "tsx watch server.ts"
   },
   "dependencies": {
-    "@hono/node-server": "^1.2.3",
     "elba-schema": "workspace:*",
-    "hono": "^3.10.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@hono/node-server": "^1.2.3",
+    "hono": "^3.10.2",
     "tsconfig": "workspace:*",
     "tsx": "^3.12.2"
   }

--- a/packages/elba-api/package.json
+++ b/packages/elba-api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "elba-api",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "tsx watch server.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.2.3",
+    "elba-schema": "workspace:*",
+    "hono": "^3.10.2",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "tsconfig": "workspace:*",
+    "tsx": "^3.12.2"
+  }
+}

--- a/packages/elba-api/server.ts
+++ b/packages/elba-api/server.ts
@@ -1,0 +1,19 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { logger } from 'hono/logger';
+import { elbaApiRoutes } from './src/routes';
+
+const app = new Hono();
+
+const port = 3522;
+const pathPrefix = '/api/rest';
+
+app.use('*', logger());
+for (const route of elbaApiRoutes) {
+  app[route.method](`${pathPrefix}${route.path}`, async ({ req: { raw: request } }) =>
+    route.handler({ request })
+  );
+}
+
+serve({ port, fetch: app.fetch });
+console.log(`elba API running on http://localhost:${port}`);

--- a/packages/elba-api/server.ts
+++ b/packages/elba-api/server.ts
@@ -10,6 +10,7 @@ const pathPrefix = '/api/rest';
 
 app.use('*', logger());
 for (const route of elbaApiRoutes) {
+  // TODO: handle authentication
   app[route.method](`${pathPrefix}${route.path}`, async ({ req: { raw: request } }) =>
     route.handler({ request })
   );

--- a/packages/elba-api/server.ts
+++ b/packages/elba-api/server.ts
@@ -16,4 +16,5 @@ for (const route of elbaApiRoutes) {
 }
 
 serve({ port, fetch: app.fetch });
+// eslint-disable-next-line no-console -- To display server running status
 console.log(`elba API running on http://localhost:${port}`);

--- a/packages/elba-api/src/index.ts
+++ b/packages/elba-api/src/index.ts
@@ -1,0 +1,2 @@
+export * from './routes'
+export * from './utils';

--- a/packages/elba-api/src/routes/authentication.ts
+++ b/packages/elba-api/src/routes/authentication.ts
@@ -1,0 +1,12 @@
+import { updateAuthenticationObjectsSchema } from 'elba-schema';
+import { createRoute } from '../utils';
+
+const path = '/authentication/objects';
+
+export const updateAuthenticationObjectsRoute = createRoute({
+  path,
+  method: 'post',
+  schema: updateAuthenticationObjectsSchema,
+});
+
+export const authenticationRoutes = [updateAuthenticationObjectsRoute];

--- a/packages/elba-api/src/routes/connection-status.ts
+++ b/packages/elba-api/src/routes/connection-status.ts
@@ -1,0 +1,12 @@
+import { updateConnectionStatusSchema } from 'elba-schema';
+import { createRoute } from '../utils';
+
+const path = '/connection-status';
+
+export const updateConnectionStatusRoute = createRoute({
+  path,
+  method: 'post',
+  schema: updateConnectionStatusSchema,
+});
+
+export const connectionStatusRoutes = [updateConnectionStatusRoute];

--- a/packages/elba-api/src/routes/data-protection.ts
+++ b/packages/elba-api/src/routes/data-protection.ts
@@ -1,0 +1,21 @@
+import { deleteDataProtectionObjectsSchema, updateDataProtectionObjectsSchema } from 'elba-schema';
+import { createRoute } from '../utils';
+
+const path = '/data-protection/objects';
+
+export const updateDataProtectionObjectsRoute = createRoute({
+  path,
+  method: 'post',
+  schema: updateDataProtectionObjectsSchema,
+});
+
+export const deleteDataProtectionObjectsRoute = createRoute({
+  path,
+  method: 'delete',
+  schema: deleteDataProtectionObjectsSchema,
+});
+
+export const dataProtectionRoutes = [
+  updateDataProtectionObjectsRoute,
+  deleteDataProtectionObjectsRoute,
+];

--- a/packages/elba-api/src/routes/index.ts
+++ b/packages/elba-api/src/routes/index.ts
@@ -1,0 +1,19 @@
+import { authenticationRoutes } from './authentication';
+import { connectionStatusRoutes } from './connection-status';
+import { dataProtectionRoutes } from './data-protection';
+import { thirdPartyAppsRoutes } from './third-party-apps';
+import { usersRoutes } from './users';
+
+export * from './authentication';
+export * from './connection-status';
+export * from './data-protection';
+export * from './third-party-apps';
+export * from './users';
+
+export const elbaApiRoutes = [
+  ...authenticationRoutes,
+  ...connectionStatusRoutes,
+  ...dataProtectionRoutes,
+  ...thirdPartyAppsRoutes,
+  ...usersRoutes,
+];

--- a/packages/elba-api/src/routes/third-party-apps.ts
+++ b/packages/elba-api/src/routes/third-party-apps.ts
@@ -1,0 +1,36 @@
+import { deleteThirdPartyAppsSchema, updateThirdPartyAppsSchema } from 'elba-schema';
+import { createRoute } from '../utils';
+
+const path = '/third-party-apps/objects';
+
+export const updateThirdPartyAppsRoute = createRoute({
+  path,
+  method: 'post',
+  schema: updateThirdPartyAppsSchema,
+  handler: async ({ data }) => {
+    const usersIds = data.apps.reduce((ids, app) => {
+      for (const user of app.users) {
+        ids.add(user.id);
+      }
+      return ids;
+    }, new Set<string>());
+
+    return Response.json({
+      data: {
+        processedApps: data.apps.length,
+        processedUsers: usersIds.size,
+      },
+    });
+  }
+});
+
+export const deleteThirdPartyAppsRoute = createRoute({
+  path,
+  method: 'delete',
+  schema: deleteThirdPartyAppsSchema,
+});
+
+export const thirdPartyAppsRoutes = [
+  updateThirdPartyAppsRoute,
+  deleteThirdPartyAppsRoute,
+];

--- a/packages/elba-api/src/routes/third-party-apps.ts
+++ b/packages/elba-api/src/routes/third-party-apps.ts
@@ -7,7 +7,7 @@ export const updateThirdPartyAppsRoute = createRoute({
   path,
   method: 'post',
   schema: updateThirdPartyAppsSchema,
-  handler: async ({ data }) => {
+  handler: ({ data }) => {
     const usersIds = data.apps.reduce((ids, app) => {
       for (const user of app.users) {
         ids.add(user.id);

--- a/packages/elba-api/src/routes/users.ts
+++ b/packages/elba-api/src/routes/users.ts
@@ -1,0 +1,21 @@
+import { deleteUsersSchema, updateUsersSchema } from 'elba-schema';
+import { createRoute } from '../utils';
+
+const path = '/users';
+
+export const updateUsersRoute = createRoute({
+  path,
+  method: 'post',
+  schema: updateUsersSchema,
+});
+
+export const deleteUsersRoute = createRoute({
+  path,
+  method: 'delete',
+  schema: deleteUsersSchema,
+});
+
+export const usersRoutes = [
+  updateUsersRoute,
+  deleteUsersRoute,
+];

--- a/packages/elba-api/src/utils.ts
+++ b/packages/elba-api/src/utils.ts
@@ -1,0 +1,57 @@
+import { baseRequestSchema } from 'elba-schema';
+import { ZodSchema, infer as zInfer } from 'zod';
+
+export type RequestHandler<T extends ZodSchema> = ({
+  request,
+  data,
+}: {
+  request: Request;
+  data: zInfer<T>;
+}) => Promise<Response>;
+
+const defaultRequestHandler = async () => {
+  return Response.json({ success: true });
+};
+
+const requestHandler = async <T extends ZodSchema>({
+  request,
+  handler,
+  schema,
+}: {
+  request: Request;
+  handler?: RequestHandler<T>;
+  schema: T;
+}) => {
+  const data = await request.json();
+  const result = baseRequestSchema.and(schema).safeParse(data);
+
+  if (!result.success) {
+    return new Response(result.error.toString(), {
+      status: 400,
+    });
+  }
+
+  if (handler) {
+    return handler({ request, data });
+  }
+
+  return defaultRequestHandler();
+};
+
+export const createRoute = <T extends ZodSchema>({
+  path,
+  method,
+  handler,
+  schema,
+}: {
+  path: string;
+  method: 'post' | 'delete';
+  handler?: ({ request }: { request: Request; data: zInfer<T> }) => Promise<Response>;
+  schema: T;
+}) => {
+  return {
+    path,
+    method,
+    handler: ({ request }: { request: Request }) => requestHandler({ request, handler, schema }),
+  };
+};

--- a/packages/elba-api/src/utils.ts
+++ b/packages/elba-api/src/utils.ts
@@ -1,5 +1,5 @@
 import { baseRequestSchema } from 'elba-schema';
-import { ZodSchema, infer as zInfer } from 'zod';
+import type { ZodSchema, infer as zInfer } from 'zod';
 
 export type RequestHandler<T extends ZodSchema> = ({
   request,

--- a/packages/elba-api/tsconfig.json
+++ b/packages/elba-api/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": ["server.ts", "src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/elba-msw/package.json
+++ b/packages/elba-msw/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint src/**.ts"
   },
   "dependencies": {
+    "elba-api": "workspace:*",
     "elba-schema": "workspace:*",
     "typescript": "^5",
     "msw": "^2.0.1",

--- a/packages/elba-msw/src/resources/authentication.ts
+++ b/packages/elba-msw/src/resources/authentication.ts
@@ -1,19 +1,5 @@
 import { http, type RequestHandler } from 'msw';
-import { updateAuthenticationObjectsSchema, baseRequestSchema } from 'elba-schema';
+import { authenticationRoutes } from 'elba-api';
 
-export const createAuthenticationRequestHandlers = (baseUrl: string): RequestHandler[] => [
-  http.post(`${baseUrl}/authentication/objects`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(updateAuthenticationObjectsSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      success: true,
-    });
-  }),
-];
+export const createAuthenticationRequestHandlers = (baseUrl: string): RequestHandler[] =>
+  authenticationRoutes.map((route) => http[route.method](`${baseUrl}${route.path}`, route.handler));

--- a/packages/elba-msw/src/resources/connection-status.ts
+++ b/packages/elba-msw/src/resources/connection-status.ts
@@ -1,19 +1,7 @@
 import { http, type RequestHandler } from 'msw';
-import { updateConnectionStatusSchema, baseRequestSchema } from 'elba-schema';
+import { connectionStatusRoutes } from 'elba-api';
 
-export const createConnectionStatusRequestHandlers = (baseUrl: string): RequestHandler[] => [
-  http.post(`${baseUrl}/connection-status`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(updateConnectionStatusSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      success: true,
-    });
-  }),
-];
+export const createConnectionStatusRequestHandlers = (baseUrl: string): RequestHandler[] =>
+  connectionStatusRoutes.map((route) =>
+    http[route.method](`${baseUrl}${route.path}`, route.handler)
+  );

--- a/packages/elba-msw/src/resources/data-protection.ts
+++ b/packages/elba-msw/src/resources/data-protection.ts
@@ -1,37 +1,5 @@
 import { http, type RequestHandler } from 'msw';
-import {
-  updateDataProtectionObjectsSchema,
-  deleteDataProtectionObjectsSchema,
-  baseRequestSchema,
-} from 'elba-schema';
+import { dataProtectionRoutes } from 'elba-api';
 
-export const createDataProtectionRequestHandlers = (baseUrl: string): RequestHandler[] => [
-  http.post(`${baseUrl}/data-protection/objects`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(updateDataProtectionObjectsSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      success: true,
-    });
-  }),
-  http.delete(`${baseUrl}/data-protection/objects`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(deleteDataProtectionObjectsSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      success: true,
-    });
-  }),
-];
+export const createDataProtectionRequestHandlers = (baseUrl: string): RequestHandler[] =>
+  dataProtectionRoutes.map((route) => http[route.method](`${baseUrl}${route.path}`, route.handler));

--- a/packages/elba-msw/src/resources/third-party-apps.ts
+++ b/packages/elba-msw/src/resources/third-party-apps.ts
@@ -1,47 +1,5 @@
 import { http, type RequestHandler } from 'msw';
-import {
-  updateThirdPartyAppsSchema,
-  deleteThirdPartyAppsSchema,
-  baseRequestSchema,
-} from 'elba-schema';
+import { thirdPartyAppsRoutes } from 'elba-api';
 
-export const createThirdPartyAppsRequestHandlers = (baseUrl: string): RequestHandler[] => [
-  http.post(`${baseUrl}/third-party-apps/objects`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(updateThirdPartyAppsSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    const usersIds = result.data.apps.reduce((ids, app) => {
-      for (const user of app.users) {
-        ids.add(user.id);
-      }
-      return ids;
-    }, new Set<string>());
-
-    return Response.json({
-      data: {
-        processedApps: result.data.apps.length,
-        processedUsers: usersIds.size,
-      },
-    });
-  }),
-  http.delete(`${baseUrl}/third-party-apps/objects`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(deleteThirdPartyAppsSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      success: true,
-    });
-  }),
-];
+export const createThirdPartyAppsRequestHandlers = (baseUrl: string): RequestHandler[] =>
+  thirdPartyAppsRoutes.map((route) => http[route.method](`${baseUrl}${route.path}`, route.handler));

--- a/packages/elba-msw/src/resources/users.ts
+++ b/packages/elba-msw/src/resources/users.ts
@@ -1,33 +1,5 @@
 import { http, type RequestHandler } from 'msw';
-import { updateUsersSchema, deleteUsersSchema, baseRequestSchema } from 'elba-schema';
+import { usersRoutes } from 'elba-api';
 
-export const createUsersRequestHandlers = (baseUrl: string): RequestHandler[] => [
-  http.post(`${baseUrl}/users`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(updateUsersSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      insertedOrUpdatedCount: result.data.users.length,
-    });
-  }),
-  http.delete(`${baseUrl}/users`, async ({ request }) => {
-    const data = await request.json();
-    const result = baseRequestSchema.and(deleteUsersSchema).safeParse(data);
-
-    if (!result.success) {
-      return new Response(result.error.toString(), {
-        status: 400,
-      });
-    }
-
-    return Response.json({
-      success: true,
-    });
-  }),
-];
+export const createUsersRequestHandlers = (baseUrl: string): RequestHandler[] =>
+  usersRoutes.map((route) => http[route.method](`${baseUrl}${route.path}`, route.handler));

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -16,7 +16,8 @@
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "strict": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "target": "es6"
   },
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,19 +23,19 @@ importers:
 
   packages/elba-api:
     dependencies:
-      '@hono/node-server':
-        specifier: ^1.2.3
-        version: 1.2.3
       elba-schema:
         specifier: workspace:*
         version: link:../elba-schema
-      hono:
-        specifier: ^3.10.2
-        version: 3.10.2
       zod:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
+      '@hono/node-server':
+        specifier: ^1.2.3
+        version: 1.2.3
+      hono:
+        specifier: ^3.10.2
+        version: 3.10.2
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -587,7 +587,7 @@ packages:
   /@hono/node-server@1.2.3:
     resolution: {integrity: sha512-IH2lpqgSSLt9sIhWBE6FivFj+0RglCNYVuBT39vkumfjqjHAwQnx7KJw9WDVNlyH+AJY0N5ImZgcIbfM5xgyBw==}
     engines: {node: '>=18.14.1'}
-    dev: false
+    dev: true
 
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
@@ -2386,7 +2386,7 @@ packages:
   /hono@3.10.2:
     resolution: {integrity: sha512-QwJLjWs3e+nZ3b5nQrrdJpYCJqiTK744jeYhX7yhZdxwcQ3KIohBfzI2dA8gSF6HEZkmFUdiKL1BelJ8utIm4w==}
     engines: {node: '>=16.0.0'}
-    dev: false
+    dev: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       '@hono/node-server':
         specifier: ^1.2.3
         version: 1.2.3
+      eslint:
+        specifier: ^8
+        version: 8.53.0
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../eslint-config-custom
       hono:
         specifier: ^3.10.2
         version: 3.10.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,33 @@ importers:
         specifier: latest
         version: 1.10.16
 
+  packages/elba-api:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.2.3
+        version: 1.2.3
+      elba-schema:
+        specifier: workspace:*
+        version: link:../elba-schema
+      hono:
+        specifier: ^3.10.2
+        version: 3.10.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
+    devDependencies:
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsx:
+        specifier: ^3.12.2
+        version: 3.14.0
+
   packages/elba-msw:
     dependencies:
+      elba-api:
+        specifier: workspace:*
+        version: link:../elba-api
       elba-schema:
         specifier: workspace:*
         version: link:../elba-schema
@@ -324,6 +349,204 @@ packages:
       statuses: 2.0.1
     dev: false
 
+  /@esbuild/android-arm64@0.18.20:
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.18.20:
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.18.20:
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.18.20:
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.18.20:
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.18.20:
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.18.20:
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.18.20:
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.18.20:
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.18.20:
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.18.20:
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.18.20:
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.18.20:
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.18.20:
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.18.20:
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.18.20:
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.18.20:
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.18.20:
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.18.20:
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.18.20:
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.18.20:
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.18.20:
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@eslint-community/eslint-utils@4.4.0(eslint@8.53.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -360,6 +583,11 @@ packages:
     resolution: {integrity: sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
+
+  /@hono/node-server@1.2.3:
+    resolution: {integrity: sha512-IH2lpqgSSLt9sIhWBE6FivFj+0RglCNYVuBT39vkumfjqjHAwQnx7KJw9WDVNlyH+AJY0N5ImZgcIbfM5xgyBw==}
+    engines: {node: '>=18.14.1'}
+    dev: false
 
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
@@ -996,6 +1224,10 @@ packages:
       update-browserslist-db: 1.0.13(browserslist@4.22.1)
     dev: true
 
+  /buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
     dependencies:
@@ -1382,6 +1614,36 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+    dev: true
+
+  /esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
     dev: true
 
   /escalade@3.1.1:
@@ -1922,7 +2184,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /function-bind@1.1.2:
@@ -2120,6 +2381,11 @@ packages:
 
   /headers-polyfill@4.0.2:
     resolution: {integrity: sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==}
+    dev: false
+
+  /hono@3.10.2:
+    resolution: {integrity: sha512-QwJLjWs3e+nZ3b5nQrrdJpYCJqiTK744jeYhX7yhZdxwcQ3KIohBfzI2dA8gSF6HEZkmFUdiKL1BelJ8utIm4w==}
+    engines: {node: '>=16.0.0'}
     dev: false
 
   /hosted-git-info@2.8.9:
@@ -3288,6 +3554,18 @@ packages:
       sort-object-keys: 1.1.3
     dev: true
 
+  /source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
+  /source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
@@ -3505,6 +3783,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
+    dev: true
+
+  /tsx@3.14.0:
+    resolution: {integrity: sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==}
+    hasBin: true
+    dependencies:
+      esbuild: 0.18.20
+      get-tsconfig: 4.7.2
+      source-map-support: 0.5.21
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /turbo-darwin-64@1.10.16:


### PR DESCRIPTION
## Description

This adds the `elba-api` package.

This package contains a minimal http server to run a mocked elba api locally.

The package is also the source of truth regarding the elba api routes, now the `elba-msw` packages import the routes request handler directly from it instead of defining them. 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
