### PR TITLE
chore: fix neondatabase version

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@elba-security/sdk": "workspace:*",
     "@neondatabase/serverless": "0.6.0",
-    "@vercel/postgres": "^0.5.1",
+    "@vercel/postgres": "0.5.1",
     "drizzle-orm": "^0.29.1",
     "inngest": "^3.6.2",
     "msw": "^2.0.1",

--- a/template/package.json
+++ b/template/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@elba-security/sdk": "workspace:*",
-    "@neondatabase/serverless": "^0.6.0",
+    "@neondatabase/serverless": "0.6.0",
     "@vercel/postgres": "^0.5.1",
     "drizzle-orm": "^0.29.1",
     "inngest": "^3.6.2",


### PR DESCRIPTION
## Description

- fix neondatabse version in template

## Additional Notes

This fix an issue introduced in version `0.6.1`. Note that version `0.7` is probably not supported by the vercel connector.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
