### PR TITLE
fix: elba signature verification

### DIFF
--- a/packages/sdk/src/webhooks/request-signature.test.ts
+++ b/packages/sdk/src/webhooks/request-signature.test.ts
@@ -5,13 +5,13 @@ import { validateWebhookRequestSignature } from './request-signature';
 describe('validateWebhookRequestSignature', () => {
   it('should succeed when the request signature is valid', async () => {
     const secret = 'test-secret';
-    const payload = '{ "data": "example" }';
+    const payload = '{"data":"example"}';
     // crypto signature computed using the above secret and payload
-    const signature = 'b1d12035603a98adf998e23052a1c99ff356cc2903322f7dd1ccc6d2e2748863';
+    const signature = '8d39b9c99e442dd3cb018aa9b6e7d83a267881c5fa558f6fba4ec0ef1e06df4c';
     const request = new Request(new URL('http://foo.bar'), {
       method: 'post',
-      body: JSON.stringify(payload),
-      headers: { 'X-Elba-Signature': signature },
+      body: payload,
+      headers: { 'X-elba-Signature': signature },
     });
 
     await expect(validateWebhookRequestSignature(request, secret)).resolves.toBe(undefined);
@@ -25,7 +25,7 @@ describe('validateWebhookRequestSignature', () => {
     const request = new Request(new URL('http://foo.bar'), {
       method: 'post',
       body: JSON.stringify(payload),
-      headers: { 'X-Elba-Signature': signature },
+      headers: { 'X-elba-Signature': signature },
     });
 
     await expect(validateWebhookRequestSignature(request, secret)).rejects.toBeInstanceOf(
@@ -45,7 +45,7 @@ describe('validateWebhookRequestSignature', () => {
     const request = new Request(new URL('http://foo.bar'), {
       method: 'get',
       body: JSON.stringify(payload),
-      headers: { 'X-Elba-Signature': signature },
+      headers: { 'X-elba-Signature': signature },
     });
 
     await expect(validateWebhookRequestSignature(request, secret)).rejects.toBeInstanceOf(

--- a/packages/sdk/src/webhooks/request-signature.test.ts
+++ b/packages/sdk/src/webhooks/request-signature.test.ts
@@ -19,12 +19,12 @@ describe('validateWebhookRequestSignature', () => {
 
   it('should fail when the request signature is invalid', async () => {
     const secret = 'test-secret';
-    const payload = '{ "data": "example" }';
+    const payload = '{"data":"example"}';
 
     const signature = 'invalid-signature';
     const request = new Request(new URL('http://foo.bar'), {
       method: 'post',
-      body: JSON.stringify(payload),
+      body: payload,
       headers: { 'X-elba-Signature': signature },
     });
 
@@ -44,7 +44,7 @@ describe('validateWebhookRequestSignature', () => {
     const signature = 'invalid-signature';
     const request = new Request(new URL('http://foo.bar'), {
       method: 'get',
-      body: JSON.stringify(payload),
+      body: payload,
       headers: { 'X-elba-Signature': signature },
     });
 

--- a/packages/sdk/src/webhooks/request-signature.ts
+++ b/packages/sdk/src/webhooks/request-signature.ts
@@ -10,10 +10,10 @@ export type ValidateWebhookRequestSignatureResult =
 export const validateWebhookRequestSignature = async (request: Request, secret: string) => {
   // cloning is mandatory to make sure that request.json() still works after this function invokation
   const requestClone = request.clone();
-  const signature = requestClone.headers.get('X-Elba-Signature');
+  const signature = requestClone.headers.get('X-elba-Signature');
 
   if (!signature) {
-    throw new ElbaError("Could not retrieve header 'X-Elba-Signature' from webhook request", {
+    throw new ElbaError("Could not retrieve header 'X-elba-Signature' from webhook request", {
       request,
     });
   }
@@ -92,7 +92,7 @@ async function createWebhookElbaSignature(secret: string, payload: string) {
   // encode the secret and payload to Uint8Array
   const encoder = new TextEncoder();
   const encodedSecret = encoder.encode(secret);
-  const encodedPayload = encoder.encode(JSON.stringify(payload));
+  const encodedPayload = encoder.encode(payload);
 
   // generate a CryptoKey from the secret
   const key = await crypto.subtle.importKey(


### PR DESCRIPTION
## Description

This fixes a bug where validating elba signature was not working due to the fact it was trying to JSON stringify a string, adding unecessary quotes wrapping the string and failing to verify correctly that the signatures were matching.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
