### PR TITLE
chore: import node crypto

### DIFF
--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'node:crypto';
+
 export const arrayBufferFromHexString = (hexString: string) => {
   const matches = hexString.match(/[0-9a-f]{2}/gi);
   if (!matches || hexString.length !== matches.length * 2) {


### PR DESCRIPTION
## Description

crypto wasn't imported  from 'node:crypto', somehow it managed to work for some devs, but it is throwing error for others, therefore it is imported 


## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
