### PR TITLE
feat(tpa-webhook-validation): add tpa refresh & delete object request webhooks validation

### DIFF
--- a/packages/schemas/src/third-party-apps.ts
+++ b/packages/schemas/src/third-party-apps.ts
@@ -41,3 +41,18 @@ export type DeleteThirdPartyApps = zInfer<typeof deleteThirdPartyAppsSchema>;
 export const thirdPartyAppsScanTriggeredWebhookDataSchema = z.object({
   organisationId: z.string().uuid(),
 });
+
+export const thirdPartyAppsRefreshObjectRequestedWebhookDataSchema = z.object({
+  organisationId: z.string().uuid(),
+  userId: z.string(),
+  appId: z.string(),
+  metadata: z.any()
+});
+
+export const thirdPartyAppsDeleteObjectRequestedWebhookDataSchema = z.object({
+  organisationId: z.string().uuid(),
+  userId: z.string(),
+  appId: z.string(),
+  metadata: z.any()
+});
+

--- a/packages/sdk/src/webhooks/event-data.test.ts
+++ b/packages/sdk/src/webhooks/event-data.test.ts
@@ -3,28 +3,64 @@ import { ElbaError } from '../error';
 import { parseWebhookEventData } from './event-data';
 
 describe('parseWebhookEventData', () => {
-  test('should throw when the payload is invalid', () => {
-    const data = { foo: 'bar' };
-    const setup = () => parseWebhookEventData('data_protection.scan_triggered', data);
-
-    expect(setup).toThrowError(ElbaError);
-    expect(setup).toThrowError('Could not validate webhook event data');
-  });
-
-  test('should returns the event data when the payload is valid', () => {
-    const data = { organisationId: '139ed8eb-2f8c-4784-b330-019d57737f06', someExtraData: 'foo' };
-    const result = parseWebhookEventData('data_protection.scan_triggered', data);
-
-    expect(result).toStrictEqual({ organisationId: data.organisationId });
-  });
-
-  test('should returns the event data when the data is instance of URLSearchParams and is valid', () => {
-    const data = new URLSearchParams({
-      organisationId: '139ed8eb-2f8c-4784-b330-019d57737f06',
-      someExtraData: 'foo',
+  describe('data_protection.scan_triggered',() => {
+    test('should throw when the payload is invalid', () => {
+      const data = { foo: 'bar' };
+      const setup = () => parseWebhookEventData('data_protection.scan_triggered', data);
+  
+      expect(setup).toThrowError(ElbaError);
+      expect(setup).toThrowError('Could not validate webhook event data');
     });
-    const result = parseWebhookEventData('data_protection.scan_triggered', data);
+  
+    test('should returns the event data when the payload is valid', () => {
+      const data = { organisationId: '139ed8eb-2f8c-4784-b330-019d57737f06', someExtraData: 'foo' };
+      const result = parseWebhookEventData('data_protection.scan_triggered', data);
+  
+      expect(result).toStrictEqual({ organisationId: data.organisationId });
+    });
+  
+    test('should returns the event data when the data is instance of URLSearchParams and is valid', () => {
+      const data = new URLSearchParams({
+        organisationId: '139ed8eb-2f8c-4784-b330-019d57737f06',
+        someExtraData: 'foo',
+      });
+      const result = parseWebhookEventData('data_protection.scan_triggered', data);
+  
+      expect(result).toStrictEqual({ organisationId: data.get('organisationId') });
+    });
+  })
 
-    expect(result).toStrictEqual({ organisationId: data.get('organisationId') });
-  });
+  describe('third_party_apps.refresh_requested',() => {
+    test('should throw when the payload is invalid', () => {
+      const data = { foo: 'bar' };
+      const setup = () => parseWebhookEventData('third_party_apps.refresh_requested', data);
+  
+      expect(setup).toThrowError(ElbaError);
+      expect(setup).toThrowError('Could not validate webhook event data');
+    });
+  
+    test('should returns the event data when the payload is valid', () => {
+      const data = { organisationId: '00000000-0000-0000-0000-000000000001', userId: 'user-id', appId: 'app-id', metadata: { someExtraData: 'foo'} };
+      const result = parseWebhookEventData('third_party_apps.refresh_requested', data);
+  
+      expect(result).toStrictEqual({ organisationId: data.organisationId, userId: data.userId, appId: data.appId, metadata:  data.metadata});
+    });
+  })
+
+  describe('third_party_apps.delete_requested',() => {
+    test('should throw when the payload is invalid', () => {
+      const data = { foo: 'bar' };
+      const setup = () => parseWebhookEventData('third_party_apps.delete_requested', data);
+  
+      expect(setup).toThrowError(ElbaError);
+      expect(setup).toThrowError('Could not validate webhook event data');
+    });
+  
+    test('should returns the event data when the payload is valid', () => {
+      const data = { organisationId: '00000000-0000-0000-0000-000000000001', userId: 'user-id', appId: 'app-id', metadata: { someExtraData: 'foo'} };
+      const result = parseWebhookEventData('third_party_apps.delete_requested', data);
+  
+      expect(result).toStrictEqual({ organisationId: data.organisationId, userId: data.userId, appId: data.appId, metadata:  data.metadata});
+    });
+  })
 });

--- a/packages/sdk/src/webhooks/event-data.ts
+++ b/packages/sdk/src/webhooks/event-data.ts
@@ -3,11 +3,15 @@ import {
   dataProtectionContentRequestedDataSchema,
   dataProtectionScanTriggeredWebhookDataSchema,
   thirdPartyAppsScanTriggeredWebhookDataSchema,
+  thirdPartyAppsRefreshObjectRequestedWebhookDataSchema,
+  thirdPartyAppsDeleteObjectRequestedWebhookDataSchema
 } from '@elba-security/schemas';
 import { ElbaError } from '../error';
 
 const eventDataSchema = {
   'third_party_apps.scan_triggered': thirdPartyAppsScanTriggeredWebhookDataSchema,
+  'third_party_apps.refresh_requested': thirdPartyAppsRefreshObjectRequestedWebhookDataSchema,
+  'third_party_apps.delete_requested': thirdPartyAppsDeleteObjectRequestedWebhookDataSchema,
   'data_protection.scan_triggered': dataProtectionScanTriggeredWebhookDataSchema,
   'data_protection.content_requested': dataProtectionContentRequestedDataSchema,
 } as const satisfies Record<string, ZodSchema>;


### PR DESCRIPTION
## Description

Include webhook validation for 
1. third party app refresh object
2. third party app delete object

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
