### PR TITLE
fix(slack): test not passing due to db order mismatch

### DIFF
--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-shared.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-shared.test.ts
@@ -151,29 +151,31 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
     });
 
     const conversationsInserted = await db.query.conversationsTable.findMany();
-    expect(conversationsInserted).toEqual([
-      {
-        id: 'channel-id',
-        isSharedExternally: true,
-        lastSyncedAt: new Date('2024-01-01T00:00:00.000Z'),
-        name: 'channel',
-        teamId: 'team-id-1',
-      },
-      {
-        id: 'channel-id',
-        isSharedExternally: true,
-        lastSyncedAt: new Date('2023-01-01T00:00:00.000Z'),
-        name: 'channel',
-        teamId: 'team-id-2',
-      },
-      {
-        id: 'channel-id',
-        isSharedExternally: true,
-        lastSyncedAt: new Date('2023-01-01T00:00:00.000Z'),
-        name: 'conversation',
-        teamId: 'team-id-3',
-      },
-    ]);
+    expect(conversationsInserted).toEqual(
+      expect.arrayContaining([
+        {
+          id: 'channel-id',
+          isSharedExternally: true,
+          lastSyncedAt: new Date('2024-01-01T00:00:00.000Z'),
+          name: 'channel',
+          teamId: 'team-id-1',
+        },
+        {
+          id: 'channel-id',
+          isSharedExternally: true,
+          lastSyncedAt: new Date('2023-01-01T00:00:00.000Z'),
+          name: 'channel',
+          teamId: 'team-id-2',
+        },
+        {
+          id: 'channel-id',
+          isSharedExternally: true,
+          lastSyncedAt: new Date('2023-01-01T00:00:00.000Z'),
+          name: 'conversation',
+          teamId: 'team-id-3',
+        },
+      ])
+    );
 
     expect(slack.SlackAPIClient).toBeCalledTimes(2);
     expect(slack.SlackAPIClient).toBeCalledWith('slack-app-level-token');


### PR DESCRIPTION
## Description

- fix slack test not passing due to db order mismatch

## Additional Notes

This test was randomly failing because the db does not guaranty to returns result in a certains order.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
