### PR TITLE
feat(api-client): add verbose mode

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint server.ts src",
     "lint:fix": "pnpm lint --fix",
-    "start": "tsx watch server.ts -v"
+    "start": "tsx watch server.ts -v",
+    "start:quiet": "tsx watch server.ts"
   },
   "dependencies": {
     "@elba-security/schemas": "workspace:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint server.ts src",
     "lint:fix": "pnpm lint --fix",
-    "start": "tsx watch server.ts"
+    "start": "tsx watch server.ts -v"
   },
   "dependencies": {
     "@elba-security/schemas": "workspace:*",
@@ -16,6 +16,7 @@
     "@elba-security/eslint-config-custom": "workspace:*",
     "@elba-security/tsconfig": "workspace:*",
     "@hono/node-server": "^1.2.3",
+    "@types/node": "^20.11.16",
     "eslint": "^8",
     "hono": "^3.11.7",
     "tsx": "^3.12.2"

--- a/packages/api-client/server.ts
+++ b/packages/api-client/server.ts
@@ -1,4 +1,5 @@
 import { serve } from '@hono/node-server';
+import type { Context, Next } from 'hono';
 import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import { elbaApiRoutes } from './src/routes';
@@ -8,7 +9,21 @@ const app = new Hono();
 const port = 3522;
 const pathPrefix = '/api/rest';
 
+const isVerboseModeEnabled = process.argv[2] && process.argv[2] === '-v';
+
+const logRequestBody = async (context: Context, next: Next) => {
+  const requestBody: unknown = await context.req.raw.clone().json();
+  // eslint-disable-next-line no-console -- To display request json body
+  console.log(JSON.stringify(requestBody, null, 2));
+  await next();
+};
+
 app.use('*', logger());
+
+if (isVerboseModeEnabled) {
+  app.use('*', logRequestBody);
+}
+
 for (const route of elbaApiRoutes) {
   // TODO: handle authentication
   app[route.method](`${pathPrefix}${route.path}`, async ({ req: { raw: request } }) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.2.3
         version: 1.2.3
+      '@types/node':
+        specifier: ^20.11.16
+        version: 20.11.16
       eslint:
         specifier: ^8
         version: 8.53.0
@@ -2356,6 +2359,12 @@ packages:
     resolution: {integrity: sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==}
     dependencies:
       undici-types: 5.26.5
+
+  /@types/node@20.11.16:
+    resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}


### PR DESCRIPTION
## Description

- add `-v` argument to `start` script that enable verbose mode
- when verbose mode is on every request bodies are logged

## Additional Notes

N/A

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
