### PR TITLE
feat(slack): add inngest conversation functions config env variables

### DIFF
--- a/apps/slack/src/common/env.ts
+++ b/apps/slack/src/common/env.ts
@@ -1,6 +1,11 @@
 import { createEnv } from '@t3-oss/env-nextjs';
 import { z } from 'zod';
 
+const zEnvRetry = () =>
+  z.coerce.number().int().min(0).max(20).optional().default(3) as unknown as z.ZodLiteral<
+    0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20
+  >;
+
 export const env = createEnv({
   isServer: process.env.NODE_ENV === 'test' ? true : undefined, // For vitest
   server: {
@@ -18,6 +23,15 @@ export const env = createEnv({
     SLACK_CONVERSATIONS_HISTORY_BATCH_SIZE: z.coerce.number().int().positive().default(200),
     SLACK_CONVERSATIONS_LIST_BATCH_SIZE: z.coerce.number().int().positive().default(200),
     SLACK_CONVERSATIONS_REPLIES_BATCH_SIZE: z.coerce.number().int().positive().default(1000),
+    SLACK_SYNC_CONVERSATIONS_RETRY: zEnvRetry(),
+    SLACK_SYNC_CONVERSATIONS_MESSAGES_CONCURRENCY: z.coerce.number().int().positive().default(10),
+    SLACK_SYNC_CONVERSATIONS_MESSAGES_RETRY: zEnvRetry(),
+    SLACK_SYNC_CONVERSATIONS_THREAD_MESSAGES_CONCURRENCY: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(10),
+    SLACK_SYNC_CONVERSATIONS_THREAD_MESSAGES_RETRY: zEnvRetry(),
     SLACK_SIGNING_SECRET: z.string().min(1),
     SLACK_USERS_LIST_BATCH_SIZE: z.coerce.number().int().positive().default(200),
   },

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
@@ -38,10 +38,10 @@ export const synchronizeConversationMessages = inngest.createFunction(
       run: 'event.data.isFirstSync ? 600 : 0',
     },
     concurrency: {
-      limit: 3,
+      limit: env.SLACK_SYNC_CONVERSATIONS_MESSAGES_CONCURRENCY,
       key: 'event.data.teamId',
     },
-    retries: 5,
+    retries: env.SLACK_SYNC_CONVERSATIONS_MESSAGES_RETRY,
   },
   {
     event: 'slack/conversations.sync.messages.requested',

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
@@ -41,10 +41,10 @@ export const synchronizeConversationThreadMessages = inngest.createFunction(
       run: 'event.data.isFirstSync ? 600 : 0',
     },
     concurrency: {
-      limit: 3,
+      limit: env.SLACK_SYNC_CONVERSATIONS_THREAD_MESSAGES_CONCURRENCY,
       key: 'event.data.teamId',
     },
-    retries: 5,
+    retries: env.SLACK_SYNC_CONVERSATIONS_THREAD_MESSAGES_RETRY,
   },
   {
     event: 'slack/conversations.sync.thread.messages.requested',

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
@@ -27,7 +27,7 @@ export const synchronizeConversations = inngest.createFunction(
     priority: {
       run: 'event.data.isFirstSync ? 600 : 0',
     },
-    retries: 5,
+    retries: env.SLACK_SYNC_CONVERSATIONS_RETRY,
   },
   {
     event: 'slack/conversations.sync.requested',


### PR DESCRIPTION
## Description

- add inngest conversation functions config env variables
- bump team function concurrency from 3 to 10

## Additional Notes

Here are the env variables:
```
    SLACK_SYNC_CONVERSATIONS_RETRY
    SLACK_SYNC_CONVERSATIONS_MESSAGES_CONCURRENCY
    SLACK_SYNC_CONVERSATIONS_MESSAGES_RETRY
    SLACK_SYNC_CONVERSATIONS_THREAD_MESSAGES_CONCURRENCY
    SLACK_SYNC_CONVERSATIONS_THREAD_MESSAGES_RETRY
```
## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
