### PR TITLE
fix(microsoft): wrong refresh token timing

### DIFF
--- a/apps/microsoft/src/app/auth/service.test.ts
+++ b/apps/microsoft/src/app/auth/service.test.ts
@@ -79,7 +79,7 @@ describe('setupOrganisation', () => {
         data: {
           organisationId: organisation.id,
         },
-        ts: now.getTime() + (expiresIn - 5) * 60 * 1000,
+        ts: now.getTime() + expiresIn * 1000 - 5 * 60 * 1000,
       },
     ]);
   });
@@ -135,7 +135,7 @@ describe('setupOrganisation', () => {
         data: {
           organisationId: organisation.id,
         },
-        ts: now.getTime() + (expiresIn - 5) * 60 * 1000,
+        ts: now.getTime() + expiresIn * 1000 - 5 * 60 * 1000,
       },
     ]);
   });

--- a/apps/microsoft/src/app/auth/service.ts
+++ b/apps/microsoft/src/app/auth/service.ts
@@ -1,4 +1,5 @@
-import { addMinutes } from 'date-fns/addMinutes';
+import { subMinutes } from 'date-fns/subMinutes';
+import { addSeconds } from 'date-fns/addSeconds';
 import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import { getToken } from '@/connectors/microsoft/auth';
@@ -53,7 +54,7 @@ export const setupOrganisation = async ({
         organisationId,
       },
       // we schedule a token refresh 5 minutes before it expires
-      ts: addMinutes(new Date(), expiresIn - 5).getTime(),
+      ts: subMinutes(addSeconds(new Date(), expiresIn), 5).getTime(),
     },
   ]);
 };

--- a/apps/microsoft/src/inngest/functions/token/refresh-token.test.ts
+++ b/apps/microsoft/src/inngest/functions/token/refresh-token.test.ts
@@ -78,7 +78,7 @@ describe('refresh-token', () => {
       data: {
         organisationId: organisation.id,
       },
-      ts: now.getTime() + (expiresIn - 5) * 60 * 1000,
+      ts: now.getTime() + expiresIn * 1000 - 5 * 60 * 1000,
     });
   });
 });

--- a/apps/microsoft/src/inngest/functions/token/refresh-token.ts
+++ b/apps/microsoft/src/inngest/functions/token/refresh-token.ts
@@ -1,4 +1,5 @@
-import { addMinutes } from 'date-fns/addMinutes';
+import { subMinutes } from 'date-fns/subMinutes';
+import { addSeconds } from 'date-fns/addSeconds';
 import { and, eq } from 'drizzle-orm';
 import { NonRetriableError } from 'inngest';
 import { db } from '@/database/client';
@@ -60,7 +61,7 @@ export const refreshToken = inngest.createFunction(
         organisationId,
       },
       // we schedule a token refresh 5 minutes before it expires
-      ts: addMinutes(new Date(), expiresIn - 5).getTime(),
+      ts: subMinutes(addSeconds(new Date(), expiresIn), 5).getTime(),
     });
   }
 );


### PR DESCRIPTION
## Description

- fix wrong refresh token timing

## Additional Notes

`expires_at` is in seconds, not minutes.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.
