### PR TITLE
docs: add docs for user and tpa sync

### DIFF
--- a/apps/microsoft/docs/third-party-apps/tpa-sync.md
+++ b/apps/microsoft/docs/third-party-apps/tpa-sync.md
@@ -1,0 +1,58 @@
+# `getApps` Function Documentation
+
+## Overview
+
+The `getApps` function is an asynchronous operation designed to fetch application details from Microsoft's API within a specific tenant. It's crucial for managing third-party applications integrated with Microsoft services.
+
+## Function Signature
+
+```javascript
+async function getApps({ tenantId, token, skipToken }: GetAppsParams)
+```
+
+## Parameters
+
+- `tenantId` (String): This is the unique identifier for the Microsoft tenant from which the applications are retrieved.
+- `token` (String): This is the authentication token required for accessing the Microsoft API.
+- `skipToken` (String | Null): Used for pagination purposes, this parameter allows the function to skip to a specific part in the list of applications, facilitating batch processing.
+
+## Return Type
+
+The function returns an object with the following structure:
+
+- `validApps` (Array of `MicrosoftApp`): These are the applications that successfully meet the defined schema criteria.
+- `invalidApps` (Array): These applications fail to meet the schema criteria and are categorized separately.
+- `nextSkipToken` (String): This token is used for continuing the retrieval process in subsequent pagination requests.
+
+## Functionality
+
+1. **URL Construction**: The function begins by constructing the API endpoint URL with necessary query parameters.
+2. **API Request**: It then performs an API request to Microsoft's service, using the provided authentication token.
+3. **Response Validation**: The function checks the success status of the API response, throwing `MicrosoftError` in case of failure.
+4. **Data Parsing**: Next, it parses the API response into a structured format.
+5. **Application Validation**: Each application data is validated against a predefined schema.
+6. **Pagination**: Finally, the function handles pagination by extracting the `nextSkipToken` from the response for future requests.
+
+## Fields in `MicrosoftApp`
+
+Each object in the `validApps` array includes the following fields:
+
+1. **`id`**: Unique identifier of the application.
+2. **`description`**: Textual description of the application.
+3. **`homepage`**: URL of the application's homepage.
+4. **`oauth2PermissionScopes`**: List of OAuth 2.0 permission scopes associated with the application.
+5. **`appDisplayName`**: The display name of the application.
+6. **`appRoleAssignedTo`**: List of application permissions and roles.
+7. **`info`**: Additional information about the application, such as the logo URL.
+8. **`verifiedPublisher`**: Information about the verified publisher of the application.
+
+## Usage
+
+The `getApps` function is primarily used for managing and retrieving information about third-party applications in a Microsoft tenant environment. It is essential for administrators and developers who need to oversee application integrations within their organization's Microsoft infrastructure.
+
+## Error Handling
+
+The function is designed to handle errors effectively:
+
+- Throws a `MicrosoftError` when the API request fails, allowing the calling code to catch and handle these exceptions appropriately.
+- Provides detailed information about the error context, especially useful for debugging and logging purposes.

--- a/apps/microsoft/docs/users/users-sync.md
+++ b/apps/microsoft/docs/users/users-sync.md
@@ -1,0 +1,54 @@
+# Users sync overview
+
+The `getUsers` function retrieves a resource from Microsoft's API containing user data. This documentation outlines the structure of the retrieved resource and explains the significance of each field.
+
+## Resource Structure
+
+The resource returned by the `getUsers` function is an object with the following fields:
+
+`validUsers`
+
+- **Type**: Array of `MicrosoftUser`
+- **Description**: This array contains user objects that have successfully passed the schema validation. Each MicrosoftUser object represents an individual user and contains detailed information about them.
+
+`invalidUsers`
+
+- **Type**: Array
+- **Description**: This array holds user objects that failed the schema validation. These objects might be missing required fields or have data in an incorrect format.
+
+`nextSkipToken`
+
+- **Type**: String
+- **Description**: This string is a token used for pagination. It represents the starting point for the next set of user data to be fetched in subsequent requests.
+
+## Fields in `MicrosoftUser`
+
+Each `MicrosoftUser` object within the `validUsers` array contains several fields, including:
+
+`id`
+
+- **Type**: String
+- **Description**: The unique identifier for the user.
+
+`mail`
+
+- **Type**: String
+- **Description**: The user's email address.
+
+`userPrincipalName`
+
+- **Type**: String
+- **Description**: The principal name of the user, often used for login and identification purposes.
+
+`displayName`
+
+- **Type**: String
+- **Description**: The full name or display name of the user.
+
+## Usage
+
+This resource is essential for applications that require detailed user information from a Microsoft tenant. The fields provide key identifiers and contact information that can be used for various purposes, including user management, communication, and security checks.
+
+## Error Handling
+
+Errors during the retrieval or parsing of this resource should be handled using the `MicrosoftError` exception to ensure robust error management in the application.


### PR DESCRIPTION
## Description

This PR adds documentation regarding the main business logic for both users sync and TPA sync, respectively : 
- `getUsers`
- `getApps`

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
