### PR TITLE
refactor: rename event name suffix to .requested

### DIFF
--- a/apps/dropbox/src/app/api/webhooks/elba/third-party-apps/start-sync/service.test.ts
+++ b/apps/dropbox/src/app/api/webhooks/elba/third-party-apps/start-sync/service.test.ts
@@ -12,7 +12,7 @@ describe('triggerThirdPartyAppsScan', () => {
     vi.restoreAllMocks();
   });
 
-  test('should schedule trigger the dropbox/third_party_apps.sync_page.triggered event', async () => {
+  test('should schedule trigger the dropbox/third_party_apps.sync_page.requested event', async () => {
     vi.setSystemTime(syncStartAt);
     await insertOrganisations();
     const send = vi.spyOn(inngest, 'send').mockResolvedValue({ ids: [] });
@@ -29,7 +29,7 @@ describe('triggerThirdPartyAppsScan', () => {
     expect(send).toBeCalledTimes(1);
 
     expect(send).toBeCalledWith({
-      name: 'dropbox/third_party_apps.sync_page.triggered',
+      name: 'dropbox/third_party_apps.sync_page.requested',
       data: {
         organisationId,
         isFirstSync: true,

--- a/apps/dropbox/src/app/api/webhooks/elba/third-party-apps/start-sync/service.ts
+++ b/apps/dropbox/src/app/api/webhooks/elba/third-party-apps/start-sync/service.ts
@@ -4,7 +4,7 @@ export const startThirdPartySync = async (organisationId: string) => {
   const syncStartedAt = Date.now();
 
   await inngest.send({
-    name: 'dropbox/third_party_apps.sync_page.triggered',
+    name: 'dropbox/third_party_apps.sync_page.requested',
     data: {
       organisationId,
       isFirstSync: true,

--- a/apps/dropbox/src/app/oauth/route.test.ts
+++ b/apps/dropbox/src/app/oauth/route.test.ts
@@ -156,7 +156,7 @@ describe('Callback dropbox', () => {
             organisationId: '00000000-0000-0000-0000-000000000001',
             expiresAt: 1688896756,
           },
-          name: 'dropbox/token.refresh.triggered',
+          name: 'dropbox/token.refresh.requested',
         },
         {
           data: {
@@ -170,7 +170,7 @@ describe('Callback dropbox', () => {
             organisationId: '00000000-0000-0000-0000-000000000001',
             syncStartedAt: SYNC_STARTED_AT,
           },
-          name: 'dropbox/users.sync_page.triggered',
+          name: 'dropbox/users.sync_page.requested',
         },
       ])
     );

--- a/apps/dropbox/src/app/oauth/service.ts
+++ b/apps/dropbox/src/app/oauth/service.ts
@@ -74,14 +74,14 @@ export const generateAccessToken = async ({
 
   await inngest.send([
     {
-      name: 'dropbox/token.refresh.triggered',
+      name: 'dropbox/token.refresh.requested',
       data: {
         organisationId,
         expiresAt: addSeconds(new Date(), expires_in).getTime(),
       },
     },
     {
-      name: 'dropbox/users.sync_page.triggered',
+      name: 'dropbox/users.sync_page.requested',
       data: {
         organisationId,
         isFirstSync: true,

--- a/apps/dropbox/src/inngest/functions/third-party-apps/schedule-apps-sync.test.ts
+++ b/apps/dropbox/src/inngest/functions/third-party-apps/schedule-apps-sync.test.ts
@@ -40,7 +40,7 @@ describe('schedule-third-party-apps-sync-jobs', () => {
     expect(step.sendEvent).toBeCalledWith(
       'sync-apps',
       selectedOrganisations.map((organisationId) => ({
-        name: 'dropbox/third_party_apps.sync_page.triggered',
+        name: 'dropbox/third_party_apps.sync_page.requested',
         data: {
           organisationId,
           isFirstSync: false,

--- a/apps/dropbox/src/inngest/functions/third-party-apps/schedule-apps-sync.ts
+++ b/apps/dropbox/src/inngest/functions/third-party-apps/schedule-apps-sync.ts
@@ -11,7 +11,7 @@ export const scheduleAppsSync = inngest.createFunction(
       await step.sendEvent(
         'sync-apps',
         organisations.map(({ organisationId }) => ({
-          name: 'dropbox/third_party_apps.sync_page.triggered',
+          name: 'dropbox/third_party_apps.sync_page.requested',
           data: { organisationId, isFirstSync: false, syncStartedAt },
         }))
       );

--- a/apps/dropbox/src/inngest/functions/third-party-apps/sync-apps.test.ts
+++ b/apps/dropbox/src/inngest/functions/third-party-apps/sync-apps.test.ts
@@ -30,7 +30,7 @@ vi.mock('@/connectors/dropbox/dbx-access', () => {
   };
 });
 
-const setup = createInngestFunctionMock(syncApps, 'dropbox/third_party_apps.sync_page.triggered');
+const setup = createInngestFunctionMock(syncApps, 'dropbox/third_party_apps.sync_page.requested');
 
 describe('run-user-sync-jobs', () => {
   beforeEach(async () => {
@@ -213,7 +213,7 @@ describe('run-user-sync-jobs', () => {
 
     expect(step.sendEvent).toBeCalledTimes(1);
     expect(step.sendEvent).toBeCalledWith('third-party-apps-run-sync-jobs', {
-      name: 'dropbox/third_party_apps.sync_page.triggered',
+      name: 'dropbox/third_party_apps.sync_page.requested',
       data: {
         cursor: 'cursor-1',
         isFirstSync: false,

--- a/apps/dropbox/src/inngest/functions/third-party-apps/sync-apps.ts
+++ b/apps/dropbox/src/inngest/functions/third-party-apps/sync-apps.ts
@@ -10,7 +10,7 @@ import { NonRetriableError } from 'inngest';
 const handler: FunctionHandler = async ({
   event,
   step,
-}: InputArgWithTrigger<'dropbox/third_party_apps.sync_page.triggered'>) => {
+}: InputArgWithTrigger<'dropbox/third_party_apps.sync_page.requested'>) => {
   const { organisationId, cursor, syncStartedAt } = event.data;
 
   const [organisation] = await getOrganisationAccessDetails(organisationId);
@@ -49,7 +49,7 @@ const handler: FunctionHandler = async ({
 
   if (result?.hasMore) {
     return await step.sendEvent('third-party-apps-run-sync-jobs', {
-      name: 'dropbox/third_party_apps.sync_page.triggered',
+      name: 'dropbox/third_party_apps.sync_page.requested',
       data: {
         ...event.data,
         cursor: result.nextCursor,
@@ -86,6 +86,6 @@ export const syncApps = inngest.createFunction(
       key: 'event.data.organisationId',
     },
   },
-  { event: 'dropbox/third_party_apps.sync_page.triggered' },
+  { event: 'dropbox/third_party_apps.sync_page.requested' },
   handler
 );

--- a/apps/dropbox/src/inngest/functions/tokens/refresh-token.test.ts
+++ b/apps/dropbox/src/inngest/functions/tokens/refresh-token.test.ts
@@ -12,7 +12,7 @@ const TOKEN_WILL_EXPIRE_IN = 14400;
 const TOKEN_EXPIRES_AT = addSeconds(new Date(TOKEN_GENERATED_AT), TOKEN_WILL_EXPIRE_IN);
 const organisationId = '00000000-0000-0000-0000-000000000001';
 
-const setup = createInngestFunctionMock(refreshToken, 'dropbox/token.refresh.triggered');
+const setup = createInngestFunctionMock(refreshToken, 'dropbox/token.refresh.requested');
 
 const mocks = vi.hoisted(() => {
   return {
@@ -90,7 +90,7 @@ describe('refreshToken', () => {
     );
     expect(step.sendEvent).toBeCalledTimes(1);
     expect(step.sendEvent).toBeCalledWith('refresh-token', {
-      name: 'dropbox/token.refresh.triggered',
+      name: 'dropbox/token.refresh.requested',
       data: {
         organisationId,
         expiresAt: TOKEN_EXPIRES_AT.getTime(),

--- a/apps/dropbox/src/inngest/functions/tokens/refresh-token.ts
+++ b/apps/dropbox/src/inngest/functions/tokens/refresh-token.ts
@@ -10,7 +10,7 @@ import { env } from '@/env';
 const handler: FunctionHandler = async ({
   event,
   step,
-}: InputArgWithTrigger<'dropbox/token.refresh.triggered'>) => {
+}: InputArgWithTrigger<'dropbox/token.refresh.requested'>) => {
   const { organisationId, expiresAt } = event.data;
 
   await step.sleepUntil('wait-before-expiration', subMinutes(new Date(expiresAt), 30));
@@ -41,7 +41,7 @@ const handler: FunctionHandler = async ({
   });
 
   await step.sendEvent('refresh-token', {
-    name: 'dropbox/token.refresh.triggered',
+    name: 'dropbox/token.refresh.requested',
     data: {
       organisationId,
       expiresAt: new Date(nextExpiresAt).getTime(),
@@ -72,6 +72,6 @@ export const refreshToken = inngest.createFunction(
     ],
     retries: env.DROPBOX_TOKEN_REFRESH_RETRIES,
   },
-  { event: 'dropbox/token.refresh.triggered' },
+  { event: 'dropbox/token.refresh.requested' },
   handler
 );

--- a/apps/dropbox/src/inngest/functions/users/schedule-user-sync.test.ts
+++ b/apps/dropbox/src/inngest/functions/users/schedule-user-sync.test.ts
@@ -38,7 +38,7 @@ describe('scheduleUserSync', () => {
       'sync-user',
       expect.arrayContaining(
         scheduledOrganisations.map((organisation) => ({
-          name: 'dropbox/users.sync_page.triggered',
+          name: 'dropbox/users.sync_page.requested',
           data: { ...organisation, isFirstSync: false, syncStartedAt: 1609459200000 },
         }))
       )

--- a/apps/dropbox/src/inngest/functions/users/schedule-user-sync.ts
+++ b/apps/dropbox/src/inngest/functions/users/schedule-user-sync.ts
@@ -11,7 +11,7 @@ export const scheduleUserSync = inngest.createFunction(
       await step.sendEvent(
         'sync-user',
         organisations.map(({ organisationId }) => ({
-          name: 'dropbox/users.sync_page.triggered',
+          name: 'dropbox/users.sync_page.requested',
           data: { organisationId, isFirstSync: false, syncStartedAt },
         }))
       );

--- a/apps/dropbox/src/inngest/functions/users/sync-user-page.test.ts
+++ b/apps/dropbox/src/inngest/functions/users/sync-user-page.test.ts
@@ -10,7 +10,7 @@ import { NonRetriableError } from 'inngest';
 const organisationId = '00000000-0000-0000-0000-000000000001';
 const syncStartedAt = 1707068979946;
 
-const setup = createInngestFunctionMock(syncUserPage, 'dropbox/users.sync_page.triggered');
+const setup = createInngestFunctionMock(syncUserPage, 'dropbox/users.sync_page.requested');
 
 const mocks = vi.hoisted(() => {
   return {
@@ -198,7 +198,7 @@ describe('syncUserPage', () => {
     expect(elbaInstance?.users.delete).toBeCalledTimes(0);
     expect(step.sendEvent).toBeCalledTimes(1);
     expect(step.sendEvent).toBeCalledWith('run-user-sync-job', {
-      name: 'dropbox/users.sync_page.triggered',
+      name: 'dropbox/users.sync_page.requested',
       data: {
         organisationId,
         isFirstSync: true,

--- a/apps/dropbox/src/inngest/functions/users/sync-user-page.ts
+++ b/apps/dropbox/src/inngest/functions/users/sync-user-page.ts
@@ -11,7 +11,7 @@ import { NonRetriableError } from 'inngest';
 const handler: FunctionHandler = async ({
   event,
   step,
-}: InputArgWithTrigger<'dropbox/users.sync_page.triggered'>) => {
+}: InputArgWithTrigger<'dropbox/users.sync_page.requested'>) => {
   const { organisationId, syncStartedAt, cursor } = event.data;
 
   const [organisation] = await getOrganisationAccessDetails(organisationId);
@@ -47,7 +47,7 @@ const handler: FunctionHandler = async ({
 
   if (users?.hasMore) {
     return await step.sendEvent('run-user-sync-job', {
-      name: 'dropbox/users.sync_page.triggered',
+      name: 'dropbox/users.sync_page.requested',
       data: { ...event.data, cursor: users.nextCursor },
     });
   }
@@ -73,6 +73,6 @@ export const syncUserPage = inngest.createFunction(
       run: 'event.data.isFirstSync ? 600 : 0',
     },
   },
-  { event: 'dropbox/users.sync_page.triggered' },
+  { event: 'dropbox/users.sync_page.requested' },
   handler
 );

--- a/apps/dropbox/src/inngest/types.ts
+++ b/apps/dropbox/src/inngest/types.ts
@@ -97,11 +97,11 @@ export type RefreshDataProtectionObjectSchema = {
 export type InngestEvents = {
   'dropbox/app.install.requested': { data: AppSchema };
   'dropbox/app.uninstall.requested': { data: AppSchema };
-  'dropbox/token.refresh.triggered': { data: RefreshTokensSchema };
+  'dropbox/token.refresh.requested': { data: RefreshTokensSchema };
   'dropbox/token.refresh.canceled': { data: RefreshTokensSchema };
-  'dropbox/users.sync_page.triggered': { data: SyncUsersData };
-  'dropbox/users.sync_page.triggered.completed': { data: SyncUsersData };
-  'dropbox/third_party_apps.sync_page.triggered': { data: RunThirdPartyAppsSyncJobsSchema };
+  'dropbox/users.sync_page.requested': { data: SyncUsersData };
+  'dropbox/users.sync_page.requested.completed': { data: SyncUsersData };
+  'dropbox/third_party_apps.sync_page.requested': { data: RunThirdPartyAppsSyncJobsSchema };
   'dropbox/third_party_apps.refresh_objects.requested': { data: RefreshThirdPartyAppsObjectSchema };
   'dropbox/third_party_apps.delete_object.requested': { data: DeleteThirdPArtyAppsObject };
   'dropbox/data_protection.shared_link.start.sync_page.requested': {

--- a/apps/microsoft/src/app/auth/service.test.ts
+++ b/apps/microsoft/src/app/auth/service.test.ts
@@ -66,7 +66,7 @@ describe('setupOrganisation', () => {
         },
       },
       {
-        name: 'microsoft/users.sync.triggered',
+        name: 'microsoft/users.sync.requested',
         data: {
           organisationId: organisation.id,
           isFirstSync: true,
@@ -75,7 +75,7 @@ describe('setupOrganisation', () => {
         },
       },
       {
-        name: 'microsoft/token.refresh.triggered',
+        name: 'microsoft/token.refresh.requested',
         data: {
           organisationId: organisation.id,
           expiresAt: now.getTime() + expiresIn * 1000,
@@ -122,7 +122,7 @@ describe('setupOrganisation', () => {
         },
       },
       {
-        name: 'microsoft/users.sync.triggered',
+        name: 'microsoft/users.sync.requested',
         data: {
           organisationId: organisation.id,
           isFirstSync: true,
@@ -131,7 +131,7 @@ describe('setupOrganisation', () => {
         },
       },
       {
-        name: 'microsoft/token.refresh.triggered',
+        name: 'microsoft/token.refresh.requested',
         data: {
           organisationId: organisation.id,
           expiresAt: now.getTime() + expiresIn * 1000,

--- a/apps/microsoft/src/app/auth/service.ts
+++ b/apps/microsoft/src/app/auth/service.ts
@@ -39,7 +39,7 @@ export const setupOrganisation = async ({
       },
     },
     {
-      name: 'microsoft/users.sync.triggered',
+      name: 'microsoft/users.sync.requested',
       data: {
         organisationId,
         isFirstSync: true,
@@ -48,7 +48,7 @@ export const setupOrganisation = async ({
       },
     },
     {
-      name: 'microsoft/token.refresh.triggered',
+      name: 'microsoft/token.refresh.requested',
       data: {
         organisationId,
         expiresAt: addSeconds(new Date(), expiresIn).getTime(),

--- a/apps/microsoft/src/inngest/client.ts
+++ b/apps/microsoft/src/inngest/client.ts
@@ -29,7 +29,7 @@ export const inngest = new Inngest({
         userId: string;
       };
     };
-    'microsoft/users.sync.triggered': {
+    'microsoft/users.sync.requested': {
       data: {
         organisationId: string;
         isFirstSync: boolean;
@@ -47,7 +47,7 @@ export const inngest = new Inngest({
         organisationId: string;
       };
     };
-    'microsoft/token.refresh.triggered': {
+    'microsoft/token.refresh.requested': {
       data: {
         organisationId: string;
         expiresAt: number;

--- a/apps/microsoft/src/inngest/functions/token/refresh-token.test.ts
+++ b/apps/microsoft/src/inngest/functions/token/refresh-token.test.ts
@@ -25,7 +25,7 @@ const expiresAt = now.getTime() + 60 * 1000;
 // next token duration
 const expiresIn = 60 * 1000;
 
-const setup = createInngestFunctionMock(refreshToken, 'microsoft/token.refresh.triggered');
+const setup = createInngestFunctionMock(refreshToken, 'microsoft/token.refresh.requested');
 
 describe('refresh-token', () => {
   beforeAll(() => {
@@ -84,7 +84,7 @@ describe('refresh-token', () => {
 
     expect(step.sendEvent).toBeCalledTimes(1);
     expect(step.sendEvent).toBeCalledWith('next-refresh', {
-      name: 'microsoft/token.refresh.triggered',
+      name: 'microsoft/token.refresh.requested',
       data: {
         organisationId: organisation.id,
         expiresAt: now.getTime() + expiresIn * 1000,

--- a/apps/microsoft/src/inngest/functions/token/refresh-token.ts
+++ b/apps/microsoft/src/inngest/functions/token/refresh-token.ts
@@ -28,7 +28,7 @@ export const refreshToken = inngest.createFunction(
     ],
     retries: env.TOKEN_REFRESH_MAX_RETRY,
   },
-  { event: 'microsoft/token.refresh.triggered' },
+  { event: 'microsoft/token.refresh.requested' },
   async ({ event, step }) => {
     const { organisationId, expiresAt } = event.data;
 
@@ -59,7 +59,7 @@ export const refreshToken = inngest.createFunction(
     });
 
     await step.sendEvent('next-refresh', {
-      name: 'microsoft/token.refresh.triggered',
+      name: 'microsoft/token.refresh.requested',
       data: {
         organisationId,
         expiresAt: new Date(nextExpiresAt).getTime(),

--- a/apps/microsoft/src/inngest/functions/users/schedule-users-syncs.test.ts
+++ b/apps/microsoft/src/inngest/functions/users/schedule-users-syncs.test.ts
@@ -41,7 +41,7 @@ describe('schedule-users-syncs', () => {
     expect(step.sendEvent).toBeCalledWith(
       'sync-organisations-users',
       organisations.map(({ id }) => ({
-        name: 'microsoft/users.sync.triggered',
+        name: 'microsoft/users.sync.requested',
         data: {
           organisationId: id,
           skipToken: null,

--- a/apps/microsoft/src/inngest/functions/users/schedule-users-syncs.ts
+++ b/apps/microsoft/src/inngest/functions/users/schedule-users-syncs.ts
@@ -17,7 +17,7 @@ export const scheduleUsersSyncs = inngest.createFunction(
       await step.sendEvent(
         'sync-organisations-users',
         organisations.map(({ id }) => ({
-          name: 'microsoft/users.sync.triggered',
+          name: 'microsoft/users.sync.requested',
           data: {
             organisationId: id,
             isFirstSync: false,

--- a/apps/microsoft/src/inngest/functions/users/sync-users.test.ts
+++ b/apps/microsoft/src/inngest/functions/users/sync-users.test.ts
@@ -26,7 +26,7 @@ const users: MicrosoftUser[] = Array.from({ length: 5 }, (_, i) => ({
   displayName: `user ${i}`,
 }));
 
-const setup = createInngestFunctionMock(syncUsers, 'microsoft/users.sync.triggered');
+const setup = createInngestFunctionMock(syncUsers, 'microsoft/users.sync.requested');
 
 describe('sync-users', () => {
   test('should abort sync when organisation is not registered', async () => {
@@ -103,7 +103,7 @@ describe('sync-users', () => {
     // check that the function continue the pagination process
     expect(step.sendEvent).toBeCalledTimes(1);
     expect(step.sendEvent).toBeCalledWith('sync-next-users-page', {
-      name: 'microsoft/users.sync.triggered',
+      name: 'microsoft/users.sync.requested',
       data: {
         organisationId: organisation.id,
         isFirstSync: false,

--- a/apps/microsoft/src/inngest/functions/users/sync-users.ts
+++ b/apps/microsoft/src/inngest/functions/users/sync-users.ts
@@ -40,7 +40,7 @@ export const syncUsers = inngest.createFunction(
     ],
     retries: env.USERS_SYNC_MAX_RETRY,
   },
-  { event: 'microsoft/users.sync.triggered' },
+  { event: 'microsoft/users.sync.requested' },
   async ({ event, step }) => {
     const { organisationId, syncStartedAt, skipToken } = event.data;
 
@@ -88,7 +88,7 @@ export const syncUsers = inngest.createFunction(
 
     if (nextSkipToken) {
       await step.sendEvent('sync-next-users-page', {
-        name: 'microsoft/users.sync.triggered',
+        name: 'microsoft/users.sync.requested',
         data: {
           ...event.data,
           skipToken: nextSkipToken,

--- a/docs/recipes/refreshing-token.md
+++ b/docs/recipes/refreshing-token.md
@@ -91,7 +91,7 @@ export const refreshSaaSToken = inngest.createFunction(
 
     // send an event that will refresh the organisation access token
     await step.sendEvent('next-refresh', {
-      name: '{SaaS}/{Saas}.token.refresh.triggered',
+      name: '{SaaS}/{Saas}.token.refresh.requested',
       data: {
         organisationId,
         expiresAt: nextExpiresAt,
@@ -147,7 +147,7 @@ export const setupOrganisation = async ({
 
   await inngest.send([
     {
-      name: '{SaaS}/users.sync.triggered',
+      name: '{SaaS}/users.sync.requested',
       data: {
         organisationId,
         isFirstSync: true,
@@ -164,7 +164,7 @@ export const setupOrganisation = async ({
     },
     // schedule a new token refresh loop
     {
-      name: '{SaaS}/token.refresh.triggered',
+      name: '{SaaS}/token.refresh.requested',
       data: {
         organisationId,
         expiresAt: addSeconds(new Date(), expiresIn).getTime(),


### PR DESCRIPTION
## Description

- rename event name suffix from .triggered to .requested

## Additional Notes

It was previously a mix without a any good reason (`requested` had more occurences then `triggered`) 

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
