### PR TITLE
chore: add some logs to troubleshoot slack endpoint to fetch data protection object content

### DIFF
--- a/apps/slack/src/app/api/webhook/elba/fetch-data-protection-object-content/route.ts
+++ b/apps/slack/src/app/api/webhook/elba/fetch-data-protection-object-content/route.ts
@@ -1,15 +1,18 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { parseWebhookEventData } from '@elba-security/sdk';
-import { fetchDataProtectionObjectContent } from './service';
+import { logger } from '@elba-security/logger';
+import { LOG_SCOPE, fetchDataProtectionObjectContent } from './service';
 
 export const runtime = 'edge';
 export const preferredRegion = 'fra1';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest) => {
+  logger.info('Retrieving json body', { scope: LOG_SCOPE });
   const data: unknown = await request.json();
 
+  logger.info('Parsing body', { scope: LOG_SCOPE });
   // eslint-disable-next-line -- metadata type is any
   const { organisationId, metadata } = parseWebhookEventData(
     'data_protection.content_requested',
@@ -21,5 +24,6 @@ export const POST = async (request: NextRequest) => {
     metadata, // eslint-disable-line -- metadata type is any,
   });
 
+  logger.error('Returning message content', { scope: LOG_SCOPE });
   return new NextResponse(content);
 };

--- a/apps/slack/src/app/api/webhook/elba/fetch-data-protection-object-content/service.ts
+++ b/apps/slack/src/app/api/webhook/elba/fetch-data-protection-object-content/service.ts
@@ -1,10 +1,13 @@
 import { and, eq } from 'drizzle-orm';
 import { SlackAPIClient } from 'slack-web-api-client';
 import type { MessageElement } from 'slack-web-api-client/dist/client/generated-response/ConversationsHistoryResponse';
+import { logger } from '@elba-security/logger';
 import { decrypt } from '@/common/crypto';
 import { teamsTable } from '@/database/schema';
 import { db } from '@/database/client';
 import { messageMetadataSchema } from '@/connectors/elba/data-protection/metadata';
+
+export const LOG_SCOPE = 'slack-fetch-data-protection-object-content';
 
 export const fetchDataProtectionObjectContent = async ({
   organisationId,
@@ -13,11 +16,14 @@ export const fetchDataProtectionObjectContent = async ({
   organisationId: string;
   metadata: any; // eslint-disable-line -- metadata type is any
 }) => {
+  logger.info('Validating metadata', { scope: LOG_SCOPE });
   const messageMetadataResult = messageMetadataSchema.safeParse(metadata);
   if (!messageMetadataResult.success) {
+    logger.error('Invalid message metadata', { scope: LOG_SCOPE });
     throw new Error('Invalid message metadata');
   }
 
+  logger.info('Retrieving team info', { scope: LOG_SCOPE });
   const { type, teamId, conversationId, messageId } = messageMetadataResult.data;
   const team = await db.query.teamsTable.findFirst({
     where: and(eq(teamsTable.id, teamId), eq(teamsTable.elbaOrganisationId, organisationId)),
@@ -26,13 +32,16 @@ export const fetchDataProtectionObjectContent = async ({
     },
   });
   if (!team) {
+    logger.error("Couldn't find team", { scope: LOG_SCOPE });
     throw new Error("Couldn't find team");
   }
 
+  logger.info('Decrypting token', { scope: LOG_SCOPE });
   const token = await decrypt(team.token);
 
   const slackClient = new SlackAPIClient(token);
   let messages: MessageElement[] | undefined;
+  logger.info('Retrieving message', { type, scope: LOG_SCOPE });
   if (type === 'reply') {
     ({ messages } = await slackClient.conversations.replies({
       channel: conversationId,
@@ -50,11 +59,13 @@ export const fetchDataProtectionObjectContent = async ({
   }
 
   if (!messages) {
+    logger.error('Failed to retrieve message', { scope: LOG_SCOPE });
     throw new Error('Failed to retrieve message');
   }
 
   const [message] = messages;
   if (!message || message.ts !== messageId) {
+    logger.error('Failed to retrieve the right message', { scope: LOG_SCOPE });
     throw new Error('Failed to retrieve the right message');
   }
 


### PR DESCRIPTION
## Description

This adds logs to the `fetch-data-protection-object-content` endpoint to troubleshoot issues

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
