### PR TITLE
feat(nextjs): add install and oauth routes builders

### DIFF
--- a/apps/github/src/app/install/route.ts
+++ b/apps/github/src/app/install/route.ts
@@ -1,38 +1,10 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
-import { type NextRequest } from 'next/server';
-import { logger } from '@elba-security/logger';
-import { z } from 'zod';
-import { ElbaInstallRedirectResponse } from '@elba-security/nextjs';
+import { createInstallRoute } from '@elba-security/nextjs';
 import { env } from '@/env';
 
 export const dynamic = 'force-dynamic';
 
-const routeInputSchema = z.object({
-  organisationId: z.string().uuid(),
-  region: z.string().min(1),
+export const GET = createInstallRoute({
+  redirectUrl: env.GITHUB_APP_INSTALL_URL,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  elbaSourceId: env.ELBA_SOURCE_ID,
 });
-
-export function GET(request: NextRequest) {
-  const region = request.nextUrl.searchParams.get('region');
-  try {
-    const input = routeInputSchema.parse({
-      organisationId: request.nextUrl.searchParams.get('organisation_id'),
-      region,
-    });
-
-    cookies().set('organisation_id', input.organisationId);
-    cookies().set('region', input.region);
-  } catch (error) {
-    logger.warn('Could not redirect user to Github app install url', {
-      error,
-    });
-    return new ElbaInstallRedirectResponse({
-      error: 'internal_error',
-      region,
-      sourceId: env.ELBA_SOURCE_ID,
-      baseUrl: env.ELBA_REDIRECT_URL,
-    });
-  }
-  redirect(env.GITHUB_APP_INSTALL_URL);
-}

--- a/apps/github/src/app/setup/route.ts
+++ b/apps/github/src/app/setup/route.ts
@@ -1,45 +1,12 @@
-import type { NextRequest } from 'next/server';
-import { RequestError } from '@octokit/request-error';
-import { z } from 'zod';
-import { logger } from '@elba-security/logger';
-import { ElbaInstallRedirectResponse } from '@elba-security/nextjs';
+import { createOAuthRoute } from '@elba-security/nextjs';
 import { env } from '@/env';
-import { setupOrganisation } from './service';
+import { handleInstallation, searchParamsSchema } from './service';
 
 export const dynamic = 'force-dynamic';
 
-const routeInputSchema = z.object({
-  organisationId: z.string().uuid(),
-  region: z.string().min(1),
-  installationId: z.coerce.number().int().positive(),
+export const GET = createOAuthRoute({
+  searchParamsSchema,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  elbaSourceId: env.ELBA_SOURCE_ID,
+  handleInstallation,
 });
-
-export async function GET(request: NextRequest) {
-  const region = request.cookies.get('region')?.value;
-  try {
-    const input = routeInputSchema.parse({
-      installationId: request.nextUrl.searchParams.get('installation_id'),
-      organisationId: request.cookies.get('organisation_id')?.value,
-      region,
-    });
-
-    await setupOrganisation(input);
-  } catch (error) {
-    logger.warn('Could not setup organisation after Github redirection', {
-      error,
-    });
-    const isUnauthorized = error instanceof RequestError && error.response?.status === 401;
-    return new ElbaInstallRedirectResponse({
-      error: isUnauthorized ? 'unauthorized' : 'internal_error',
-      region,
-      sourceId: env.ELBA_SOURCE_ID,
-      baseUrl: env.ELBA_REDIRECT_URL,
-    });
-  }
-
-  return new ElbaInstallRedirectResponse({
-    region,
-    sourceId: env.ELBA_SOURCE_ID,
-    baseUrl: env.ELBA_REDIRECT_URL,
-  });
-}

--- a/apps/github/src/app/setup/service.ts
+++ b/apps/github/src/app/setup/service.ts
@@ -1,19 +1,19 @@
+import type { InstallationHandler } from '@elba-security/nextjs';
+import { z } from 'zod';
 import { getInstallation } from '@/connectors/github/installation';
 import { inngest } from '@/inngest/client';
 import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 
-type SetupOrganisationParams = {
-  installationId: number;
-  organisationId: string;
-  region: string;
-};
+export const searchParamsSchema = z.object({
+  installation_id: z.coerce.number().int().positive(),
+});
 
-export const setupOrganisation = async ({
-  installationId,
+export const handleInstallation: InstallationHandler<typeof searchParamsSchema> = async ({
   organisationId,
   region,
-}: SetupOrganisationParams) => {
+  searchParams: { installation_id: installationId },
+}) => {
   const installation = await getInstallation(installationId);
 
   if (installation.account.type !== 'Organization') {
@@ -66,6 +66,4 @@ export const setupOrganisation = async ({
       },
     },
   ]);
-
-  return organisation;
 };

--- a/apps/microsoft/src/app/auth/route.ts
+++ b/apps/microsoft/src/app/auth/route.ts
@@ -1,59 +1,14 @@
-import type { NextRequest } from 'next/server';
-import { z } from 'zod';
-import { logger } from '@elba-security/logger';
-import { ElbaInstallRedirectResponse } from '@elba-security/nextjs';
+import { createOAuthRoute } from '@elba-security/nextjs';
 import { env } from '@/env';
-import { setupOrganisation } from './service';
+import { handleInstallation, searchParamsSchema } from './service';
 
 export const preferredRegion = 'fra1';
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
-const routeInputSchema = z.object({
-  organisationId: z.string().uuid(),
-  region: z.string().min(1),
-  adminConsent: z.string().transform((value) => value.toLocaleLowerCase() === 'true'),
-  tenantId: z.string().min(1),
+export const GET = createOAuthRoute({
+  searchParamsSchema,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  elbaSourceId: env.ELBA_SOURCE_ID,
+  handleInstallation,
 });
-
-export async function GET(request: NextRequest) {
-  const region = request.cookies.get('region')?.value;
-  try {
-    const input = routeInputSchema.parse({
-      organisationId: request.cookies.get('organisation_id')?.value,
-      region: request.cookies.get('region')?.value,
-      tenantId: request.nextUrl.searchParams.get('tenant'),
-      adminConsent: request.nextUrl.searchParams.get('admin_consent'),
-    });
-
-    if (!input.adminConsent) {
-      logger.warn('Could not setup organisation after Microsoft redirection', {
-        error: 'admin_consent was not given',
-      });
-      return new ElbaInstallRedirectResponse({
-        sourceId: env.ELBA_SOURCE_ID,
-        baseUrl: env.ELBA_REDIRECT_URL,
-        region,
-        error: 'unauthorized',
-      });
-    }
-
-    await setupOrganisation(input);
-  } catch (error) {
-    logger.warn('Could not setup organisation after Microsoft redirection', {
-      error,
-    });
-    return new ElbaInstallRedirectResponse({
-      sourceId: env.ELBA_SOURCE_ID,
-      baseUrl: env.ELBA_REDIRECT_URL,
-      region,
-      error: 'internal_error',
-    });
-  }
-
-  return new ElbaInstallRedirectResponse({
-    sourceId: env.ELBA_SOURCE_ID,
-    baseUrl: env.ELBA_REDIRECT_URL,
-    region,
-  });
-}

--- a/apps/microsoft/src/app/auth/service.test.ts
+++ b/apps/microsoft/src/app/auth/service.test.ts
@@ -5,7 +5,7 @@ import * as authConnector from '@/connectors/microsoft/auth';
 import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import { inngest } from '@/inngest/client';
-import { setupOrganisation } from './service';
+import { handleInstallation } from './service';
 
 const tenantId = 'some-tenant';
 const token = 'some-token';
@@ -20,7 +20,7 @@ const organisation = {
   region: 'eu',
 };
 
-describe('setupOrganisation', () => {
+describe('handleInstallation', () => {
   beforeAll(() => {
     vi.setSystemTime(now);
   });
@@ -36,10 +36,13 @@ describe('setupOrganisation', () => {
     vi.spyOn(crypto, 'encrypt').mockResolvedValue(token);
 
     await expect(
-      setupOrganisation({
+      handleInstallation({
         organisationId: organisation.id,
-        tenantId,
         region,
+        searchParams: {
+          admin_consent: true,
+          tenant: tenantId,
+        },
       })
     ).resolves.toBeUndefined();
 
@@ -92,10 +95,13 @@ describe('setupOrganisation', () => {
     await db.insert(organisationsTable).values(organisation);
 
     await expect(
-      setupOrganisation({
+      handleInstallation({
         organisationId: organisation.id,
-        tenantId,
         region,
+        searchParams: {
+          admin_consent: true,
+          tenant: tenantId,
+        },
       })
     ).resolves.toBeUndefined();
 
@@ -148,10 +154,13 @@ describe('setupOrganisation', () => {
     const getToken = vi.spyOn(authConnector, 'getToken').mockRejectedValue(error);
 
     await expect(
-      setupOrganisation({
+      handleInstallation({
         organisationId: organisation.id,
-        tenantId: wrongTenantId,
         region,
+        searchParams: {
+          admin_consent: true,
+          tenant: 'wrong-tenant-id',
+        },
       })
     ).rejects.toThrowError(error);
 

--- a/apps/microsoft/src/app/install/route.ts
+++ b/apps/microsoft/src/app/install/route.ts
@@ -1,37 +1,16 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
-import { type NextRequest } from 'next/server';
-import { z } from 'zod';
-import { logger } from '@elba-security/logger';
+import { createInstallRoute } from '@elba-security/nextjs';
 import { env } from '@/env';
 
 export const preferredRegion = 'fra1';
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
-const routeInputSchema = z.object({
-  organisationId: z.string().uuid(),
-  region: z.string().min(1),
+const redirectUrl = new URL(env.MICROSOFT_INSTALL_URL);
+redirectUrl.searchParams.append('client_id', env.MICROSOFT_CLIENT_ID);
+redirectUrl.searchParams.append('redirect_uri', env.MICROSOFT_REDIRECT_URI);
+
+export const GET = createInstallRoute({
+  redirectUrl,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  elbaSourceId: env.ELBA_SOURCE_ID,
 });
-
-export function GET(request: NextRequest) {
-  try {
-    const { organisationId, region } = routeInputSchema.parse({
-      organisationId: request.nextUrl.searchParams.get('organisation_id'),
-      region: request.nextUrl.searchParams.get('region'),
-    });
-
-    cookies().set('organisation_id', organisationId);
-    cookies().set('region', region);
-  } catch (error) {
-    logger.warn('Could not redirect user to Microsoft app install url', {
-      error,
-    });
-    redirect(`${env.ELBA_REDIRECT_URL}?source_id=${env.ELBA_SOURCE_ID}&error=internal_error`);
-  }
-  const url = new URL(env.MICROSOFT_INSTALL_URL);
-  url.searchParams.append('client_id', env.MICROSOFT_CLIENT_ID);
-  url.searchParams.append('redirect_uri', env.MICROSOFT_REDIRECT_URI);
-
-  redirect(url.toString());
-}

--- a/apps/slack/src/app/install/route.ts
+++ b/apps/slack/src/app/install/route.ts
@@ -1,37 +1,13 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
-import { type NextRequest } from 'next/server';
-import { logger } from '@elba-security/logger';
-import { ElbaInstallRedirectResponse } from '@elba-security/nextjs';
+import { createInstallRoute } from '@elba-security/nextjs';
 import { getSlackInstallationUrl } from '@/connectors/slack/oauth';
 import { env } from '@/common/env';
 
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
-export const GET = (request: NextRequest) => {
-  const organisationId = request.nextUrl.searchParams.get('organisation_id');
-  const region = request.nextUrl.searchParams.get('region');
-
-  if (!organisationId || !region) {
-    logger.error('Failed to install slack, missing organisation id / region', {
-      organisationId,
-      region,
-    });
-    return new ElbaInstallRedirectResponse({
-      region,
-      sourceId: env.ELBA_SOURCE_ID,
-      baseUrl: env.ELBA_REDIRECT_URL,
-      error: 'internal_error',
-    });
-  }
-
-  const state = crypto.randomUUID();
-  const slackInstallationUrl = getSlackInstallationUrl(state);
-
-  cookies().set('state', state);
-  cookies().set('organisationId', organisationId);
-  cookies().set('region', region);
-
-  redirect(slackInstallationUrl);
-};
+export const GET = createInstallRoute({
+  elbaSourceId: env.ELBA_SOURCE_ID,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  redirectUrl: getSlackInstallationUrl(),
+  withState: true,
+});

--- a/apps/slack/src/app/oauth/route.ts
+++ b/apps/slack/src/app/oauth/route.ts
@@ -1,88 +1,14 @@
-import type { NextRequest } from 'next/server';
-import { logger } from '@elba-security/logger';
-import { z } from 'zod';
-import { ElbaInstallRedirectResponse } from '@elba-security/nextjs';
+import { createOAuthRoute } from '@elba-security/nextjs';
 import { env } from '@/common/env';
-import { handleSlackInstallation } from './service';
+import { handleSlackInstallation, searchParamsSchema } from './service';
 
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
-const routeErrorInputSchema = z.union([
-  z.object({
-    error: z.string(),
-    error_description: z.string(),
-  }),
-  z.object({
-    state: z.string(),
-    code: z.string(),
-  }),
-]);
-
-const cookiesSchema = z.object({
-  state: z.string(),
-  organisationId: z.string(),
-  region: z.string(),
+export const GET = createOAuthRoute({
+  searchParamsSchema,
+  handleInstallation: handleSlackInstallation,
+  elbaSourceId: env.ELBA_SOURCE_ID,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  withState: true,
 });
-
-export const GET = async (request: NextRequest) => {
-  const searchParams = [...request.nextUrl.searchParams.entries()].reduce<Record<string, string>>(
-    (acc, [key, value]) => ({ ...acc, [key]: value }),
-    {}
-  );
-
-  const region = request.cookies.get('region')?.value;
-
-  try {
-    const cookies = cookiesSchema.parse({
-      state: request.cookies.get('state')?.value,
-      organisationId: request.cookies.get('organisationId')?.value,
-      region,
-    });
-
-    const searchParamsResult = routeErrorInputSchema.safeParse(searchParams);
-
-    if (
-      !searchParamsResult.success ||
-      ('state' in searchParamsResult && searchParamsResult.state !== cookies.state)
-    ) {
-      throw new Error('Failed to parse oauth data and verify state');
-    }
-
-    if ('error' in searchParamsResult.data) {
-      logger.error('Got an error from Slack', {
-        organisationId: cookies.organisationId,
-        region,
-        error: searchParamsResult.data.error,
-        errorDescription: searchParamsResult.data.error_description,
-      });
-      return new ElbaInstallRedirectResponse({
-        region,
-        sourceId: env.ELBA_SOURCE_ID,
-        baseUrl: env.ELBA_REDIRECT_URL,
-        error: 'unauthorized',
-      });
-    }
-
-    await handleSlackInstallation({
-      organisationId: cookies.organisationId,
-      region: cookies.region,
-      code: searchParamsResult.data.code,
-    });
-  } catch (error) {
-    logger.error('An error occurred during Slack oauth flow', { cause: error });
-
-    return new ElbaInstallRedirectResponse({
-      region,
-      sourceId: env.ELBA_SOURCE_ID,
-      baseUrl: env.ELBA_REDIRECT_URL,
-      error: 'internal_error',
-    });
-  }
-
-  return new ElbaInstallRedirectResponse({
-    region,
-    sourceId: env.ELBA_SOURCE_ID,
-    baseUrl: env.ELBA_REDIRECT_URL,
-  });
-};

--- a/apps/slack/src/app/oauth/service.test.ts
+++ b/apps/slack/src/app/oauth/service.test.ts
@@ -88,7 +88,9 @@ describe('handleSlackInstallation', () => {
     await handleSlackInstallation({
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
-      code: 'code',
+      searchParams: {
+        code: 'code',
+      },
     });
 
     expect(slack.SlackAPIClient).toBeCalledTimes(1);
@@ -190,7 +192,9 @@ describe('handleSlackInstallation', () => {
       handleSlackInstallation({
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
-        code: 'code',
+        searchParams: {
+          code: 'code',
+        },
       })
     ).rejects.toThrowError('Unsupported token type');
 
@@ -284,7 +288,9 @@ describe('handleSlackInstallation', () => {
       handleSlackInstallation({
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
-        code: 'code',
+        searchParams: {
+          code: 'code',
+        },
       })
     ).rejects.toThrowError('Missing OAuth scopes');
 
@@ -379,7 +385,9 @@ describe('handleSlackInstallation', () => {
       handleSlackInstallation({
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
-        code: 'code',
+        searchParams: {
+          code: 'code',
+        },
       })
     ).rejects.toThrowError('Slack enterprise is not supported');
 
@@ -474,7 +482,9 @@ describe('handleSlackInstallation', () => {
       handleSlackInstallation({
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
-        code: 'code',
+        searchParams: {
+          code: 'code',
+        },
       })
     ).rejects.toThrowError('User is not admin');
 

--- a/apps/slack/src/app/oauth/service.ts
+++ b/apps/slack/src/app/oauth/service.ts
@@ -1,5 +1,7 @@
 import { SlackAPIClient } from 'slack-web-api-client';
 import { logger } from '@elba-security/logger';
+import type { InstallationHandler } from '@elba-security/nextjs';
+import { z } from 'zod';
 import { encrypt } from '@/common/crypto';
 import { env } from '@/common/env';
 import { getSlackMissingScopes } from '@/connectors/slack/oauth';
@@ -8,14 +10,14 @@ import { teamsTable } from '@/database/schema';
 import { slackTeamSchema } from '@/connectors/slack/teams';
 import { inngest } from '@/inngest/client';
 
-export const handleSlackInstallation = async ({
+export const searchParamsSchema = z.object({
+  code: z.string().min(1),
+});
+
+export const handleSlackInstallation: InstallationHandler<typeof searchParamsSchema> = async ({
   organisationId,
   region,
-  code,
-}: {
-  organisationId: string;
-  region: string;
-  code: string;
+  searchParams: { code },
 }) => {
   const slackClient = new SlackAPIClient();
   let accessToken: string | undefined;

--- a/apps/slack/src/connectors/slack/oauth.ts
+++ b/apps/slack/src/connectors/slack/oauth.ts
@@ -23,11 +23,10 @@ export const getSlackMissingScopes = (scope: string) => {
   return missingScopes;
 };
 
-export const getSlackInstallationUrl = (state: string) => {
+export const getSlackInstallationUrl = () => {
   const url = new URL('https://slack.com/oauth/v2/authorize');
   url.searchParams.append('client_id', env.SLACK_CLIENT_ID);
   url.searchParams.append('user_scope', slackUserScopes.join(','));
-  url.searchParams.append('state', state);
 
   return url.toString();
 };

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -14,6 +14,76 @@ _Make sure all peerDependencies are installed. It should be the case if you have
 
 ## API Reference
 
+### Routes
+
+#### createInstallRoute
+
+Create an `/install` route handler that will redirect the user to the given `redirectUrl`. It set cookies for `organisation_id` & `region` using the search parameters.
+When used with the option `withState: true` it set a random `state` cookie and append the `state` search parameter to the given `redirectUrl`.
+
+**Example:**
+
+```ts
+// src/api/install/route.ts
+import { createInstallRoute } from '@elba-security/nextjs';
+import { env } from '@/env';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = createInstallRoute({
+  redirectUrl: env.MY_SAAS_INSTALL_URL,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  elbaSourceId: env.ELBA_SOURCE_ID,
+  withState: true,
+});
+```
+
+#### createOAuthRoute
+
+Validate the response of oauth redirection with the given schema. If used with `withState: true`, it will make sure that the cookie and the response search parameter `state` has the same value.
+When the response is valid it invoke the installation handler and then redirect the user to elba.
+When the response is not valid or when the installation handler throw an error, it redirect the user to elba with an error message.
+
+**Example:**
+
+```ts
+// src/api/auth/route.ts
+import { createOAuthRoute } from '@elba-security/nextjs';
+import { env } from '@/env';
+import { handleInstallation, searchParamsSchema } from './service';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = createOAuthRoute({
+  searchParamsSchema,
+  elbaRedirectUrl: env.ELBA_REDIRECT_URL,
+  elbaSourceId: env.ELBA_SOURCE_ID,
+  handleInstallation,
+  withState: true,
+});
+```
+
+```ts
+// src/api/auth/service.ts
+import { z } from 'zod';
+import type { InstallationHandler } from '@elba-security/nextjs';
+import { getToken } from '@/connectors/SaasName/auth';
+
+export const searchParamsSchema = z.object({
+  code: z.string().min(1),
+});
+
+export const handleInstallation: InstallationHandler<typeof searchParamsSchema> = async ({
+  organisationId,
+  region,
+  searchParams: { code },
+}) => {
+  const token = await getToken(code);
+  // proceed with the installation
+  // ...
+};
+```
+
 ### Middleware
 
 #### createElbaMiddleware

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -3,3 +3,4 @@ export {
   ElbaInstallRedirectResponse,
   type ElbaInstallRedirectResponseOptions,
 } from './install-redirect-response';
+export * from './routes';

--- a/packages/nextjs/src/routes/index.ts
+++ b/packages/nextjs/src/routes/index.ts
@@ -1,0 +1,2 @@
+export * from './install-route';
+export * from './oauth-route';

--- a/packages/nextjs/src/routes/install-route.ts
+++ b/packages/nextjs/src/routes/install-route.ts
@@ -1,0 +1,54 @@
+import { cookies } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@elba-security/logger';
+import { ElbaInstallRedirectResponse } from '../install-redirect-response';
+
+const routeInputSchema = z.object({
+  organisationId: z.string().uuid(),
+  region: z.string().min(1),
+});
+
+export type CreateInstallRouteOptions = {
+  redirectUrl: string | URL;
+  elbaRedirectUrl: string | URL;
+  elbaSourceId: string;
+  withState?: boolean;
+};
+
+export const createInstallRoute =
+  ({ redirectUrl, elbaRedirectUrl, elbaSourceId, withState = false }: CreateInstallRouteOptions) =>
+  (request: NextRequest) => {
+    try {
+      const { organisationId, region } = routeInputSchema.parse({
+        organisationId: request.nextUrl.searchParams.get('organisation_id'),
+        region: request.nextUrl.searchParams.get('region'),
+      });
+      const locationHeaderUrl = new URL(redirectUrl);
+
+      if (withState) {
+        const state = crypto.randomUUID();
+        cookies().set('state', state);
+        locationHeaderUrl.searchParams.append('state', state);
+      }
+      cookies().set('organisation_id', organisationId);
+      cookies().set('region', region);
+
+      return new NextResponse(null, {
+        status: 307,
+        headers: {
+          Location: locationHeaderUrl.toString(),
+        },
+      });
+    } catch (error) {
+      logger.warn('Could not redirect user to install url', {
+        error,
+      });
+      return new ElbaInstallRedirectResponse({
+        baseUrl: elbaRedirectUrl.toString(),
+        sourceId: elbaSourceId.toString(),
+        region: request.nextUrl.searchParams.get('region'),
+        error: 'internal_error',
+      });
+    }
+  };

--- a/packages/nextjs/src/routes/oauth-route.ts
+++ b/packages/nextjs/src/routes/oauth-route.ts
@@ -1,0 +1,103 @@
+import type { NextRequest } from 'next/server';
+import { logger } from '@elba-security/logger';
+import { z } from 'zod';
+import { ElbaInstallRedirectResponse } from '../install-redirect-response';
+
+const cookiesSchema = z.object({
+  organisationId: z.string(),
+  region: z.string(),
+});
+
+const isStateValid = (request: NextRequest) => {
+  const stateParam = request.nextUrl.searchParams.get('state');
+  const cookieParam = request.cookies.get('state')?.value;
+  if (!stateParam || !cookieParam || stateParam !== cookieParam) {
+    return false;
+  }
+  return true;
+};
+
+export type InstallationHandler<S extends z.AnyZodObject> = (params: {
+  region: string;
+  organisationId: string;
+  searchParams: z.infer<S>;
+}) => Promise<void>;
+
+type CreateOAuthRouteOptions<S extends z.AnyZodObject> = {
+  searchParamsSchema: S;
+  withState?: boolean;
+  elbaRedirectUrl: string | URL;
+  elbaSourceId: string;
+  handleInstallation: InstallationHandler<S>;
+};
+
+export const createOAuthRoute =
+  <S extends z.AnyZodObject = z.AnyZodObject>({
+    searchParamsSchema,
+    withState = false,
+    handleInstallation,
+    elbaRedirectUrl,
+    elbaSourceId,
+  }: CreateOAuthRouteOptions<S>) =>
+  async (request: NextRequest) => {
+    const searchParams = Object.fromEntries(request.nextUrl.searchParams.entries());
+    const region = request.cookies.get('region')?.value;
+
+    try {
+      const cookies = cookiesSchema.parse({
+        organisationId: request.cookies.get('organisation_id')?.value,
+        region,
+      });
+
+      const searchParamsResult = searchParamsSchema.safeParse(searchParams);
+
+      if (!searchParamsResult.success) {
+        logger.error('Could not validate search params', {
+          organisationId: cookies.organisationId,
+          region,
+          validationError: searchParamsResult.error,
+          searchParams,
+        });
+        return new ElbaInstallRedirectResponse({
+          region,
+          sourceId: elbaSourceId,
+          baseUrl: elbaRedirectUrl.toString(),
+          error: 'unauthorized',
+        });
+      }
+
+      if (withState && !isStateValid(request)) {
+        logger.error('Could not validate oauth state', {
+          organisationId: cookies.organisationId,
+          region,
+          searchParams,
+        });
+        return new ElbaInstallRedirectResponse({
+          region,
+          sourceId: elbaSourceId,
+          baseUrl: elbaRedirectUrl.toString(),
+          error: 'unauthorized',
+        });
+      }
+
+      await handleInstallation({
+        organisationId: cookies.organisationId,
+        region: cookies.region,
+        searchParams: searchParamsResult.data,
+      });
+    } catch (error) {
+      logger.error('Could not install integration', { cause: error });
+      return new ElbaInstallRedirectResponse({
+        region,
+        sourceId: elbaSourceId,
+        baseUrl: elbaRedirectUrl.toString(),
+        error: 'internal_error',
+      });
+    }
+
+    return new ElbaInstallRedirectResponse({
+      region,
+      sourceId: elbaSourceId,
+      baseUrl: elbaRedirectUrl.toString(),
+    });
+  };


### PR DESCRIPTION
## Description

- add install & oauth routes to @elba-security/next-js
- implement it in slack / github / microsoft

## Additional Notes

I have tested it on github + microsoft, but not in slack. The next-js package readme is updated with explaination & use case. 
I should update template as well (after review).

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.
