### PR TITLE
chore: set serverless function maximum execution time to 60 seconds

### DIFF
--- a/template/vercel.json
+++ b/template/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "src/app/api/**/*": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
## Description

This increases the serverless function maximum execution time to 60 seconds. Currently the default serverless function maximum execution time is 15 seconds, [see vercel blogpost here](https://vercel.com/changelog/serverless-functions-can-now-run-up-to-5-minutes).
It should avoid timeouts of time consuming inngest steps / functions.
For now only the `/api` path is affected.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
