### PR TITLE
fix(slack): return empty content when fetch data protection object content webhook hit rate limit

### DIFF
--- a/apps/slack/src/app/api/webhook/elba/fetch-data-protection-object-content/service.test.ts
+++ b/apps/slack/src/app/api/webhook/elba/fetch-data-protection-object-content/service.test.ts
@@ -7,7 +7,10 @@ import { fetchDataProtectionObjectContent } from './service';
 
 describe('fetch-data-protection-object-content', () => {
   beforeAll(() => {
-    vi.mock('slack-web-api-client');
+    vi.mock('slack-web-api-client', async (importOriginal) => ({
+      // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- this is a mock
+      ...(await importOriginal<typeof import('slack-web-api-client')>()),
+    }));
     vi.mock('@/common/crypto');
   });
 
@@ -127,6 +130,61 @@ describe('fetch-data-protection-object-content', () => {
       },
     });
     expect(result).toEqual('text');
+
+    expect(crypto.decrypt).toBeCalledTimes(1);
+    expect(crypto.decrypt).toBeCalledWith('token');
+
+    expect(slack.SlackAPIClient).toBeCalledTimes(1);
+    expect(slack.SlackAPIClient).toBeCalledWith('decrypted-token');
+
+    expect(historyMock).toBeCalledTimes(0);
+
+    expect(repliesMock).toBeCalledTimes(1);
+    expect(repliesMock).toBeCalledWith({
+      channel: 'channel-id',
+      inclusive: true,
+      limit: 1,
+      ts: 'message-id',
+    });
+  });
+
+  it('Should successfully return empty body when rate limit is reached', async () => {
+    const rateLimitError = new slack.SlackAPIError('unknown', 'ratelimited', {
+      headers: new Headers(),
+      ok: false,
+    });
+    const historyMock = vi.fn().mockRejectedValue(rateLimitError);
+    const repliesMock = vi.fn().mockRejectedValue(rateLimitError);
+
+    vi.spyOn(crypto, 'decrypt').mockResolvedValue('decrypted-token');
+
+    vi.spyOn(slack, 'SlackAPIClient').mockReturnValue({
+      // @ts-expect-error -- this is a mock
+      conversations: {
+        history: historyMock,
+        replies: repliesMock,
+      },
+    });
+
+    await db.insert(teamsTable).values({
+      adminId: 'admin-id',
+      elbaOrganisationId: '00000000-0000-0000-0000-000000000001',
+      elbaRegion: 'eu',
+      id: 'team-id',
+      token: 'token',
+      url: 'https://url',
+    });
+
+    const result = await fetchDataProtectionObjectContent({
+      organisationId: '00000000-0000-0000-0000-000000000001',
+      metadata: {
+        type: 'reply',
+        teamId: 'team-id',
+        conversationId: 'channel-id',
+        messageId: 'message-id',
+      },
+    });
+    expect(result).toEqual(null);
 
     expect(crypto.decrypt).toBeCalledTimes(1);
     expect(crypto.decrypt).toBeCalledWith('token');


### PR DESCRIPTION
## Description

This updates the fetch data protection object content webhook to return an empty content when hitting rate limit to avoid spamming the Slack API 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
