### PR TITLE
chore: get files metadata batchwise

### DIFF
--- a/apps/dropbox/src/connectors/utils/format-file-and-folders-to-elba.ts
+++ b/apps/dropbox/src/connectors/utils/format-file-and-folders-to-elba.ts
@@ -38,6 +38,7 @@ export const formatFilesToAdd = ({
 
     const isFile = file['.tag'] === 'file';
 
+    // IF the  folder doesn't have shared_folder_id, ignore it
     if (!isFile && !file.shared_folder_id) {
       return [];
     }

--- a/apps/dropbox/src/connectors/utils/format-shared-links.ts
+++ b/apps/dropbox/src/connectors/utils/format-shared-links.ts
@@ -10,7 +10,7 @@ export const filterSharedLinks = (sharedLinks: sharing.ListSharedLinksResult['li
       link_permissions.resolved_visibility?.['.tag'] ??
       null;
 
-    if (!id || !effectiveAudience || !link?.path_lower) {
+    if (!id || !effectiveAudience) {
       return acc;
     }
 

--- a/apps/dropbox/src/connectors/utils/helpers.ts
+++ b/apps/dropbox/src/connectors/utils/helpers.ts
@@ -1,0 +1,18 @@
+export const chunkArray = <T>(array: T[], chunkSize: number): T[][] => {
+  if (!Array.isArray(array)) {
+    throw new TypeError('The first argument must be an array.');
+  }
+
+  if (typeof chunkSize !== 'number' || chunkSize <= 0) {
+    throw new RangeError('The chunk size must be a positive number.');
+  }
+
+  const chunks: T[][] = [];
+  const length = array.length;
+
+  for (let i = 0; i < length; i += chunkSize) {
+    chunks.push(array.slice(i, i + chunkSize));
+  }
+
+  return chunks;
+};

--- a/apps/dropbox/src/env.ts
+++ b/apps/dropbox/src/env.ts
@@ -33,6 +33,6 @@ export const env = z
     DROPBOX_REMOVE_ORGANISATION_MAX_RETRY: zEnvRetry().default(5),
     DROPBOX_LIST_FILE_MEMBERS_LIMIT: zEnvInt().default(300), // UInt32(min=1, max=300)
     DROPBOX_LIST_FOLDER_MEMBERS_LIMIT: zEnvInt().default(1000), // UInt32(min=1, max=1000)
-    DROPBOX_LIST_FOLDER_BATCH_SIZE: zEnvInt().default(500), // UInt32(min=1, max=1000)
+    DROPBOX_LIST_FOLDER_BATCH_SIZE: zEnvInt().default(400), // UInt32(min=1, max=1000)
   })
   .parse(process.env);


### PR DESCRIPTION
## Description

At the moment we are getting the file's metadata individually & this behaviour is cause for request too many request issue , in this PR the fetch metadata method changed to batchwise, therefore very few requests will be mad to fetch files metadata.
 
## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
