### PR TITLE
fix: too many open connections postgres error when running tests

### DIFF
--- a/packages/test-utils/src/vitest/setup-database.ts
+++ b/packages/test-utils/src/vitest/setup-database.ts
@@ -12,4 +12,5 @@ beforeEach(async () => {
   const pg = postgres(process.env.DATABASE_URL);
   const db = drizzle(pg);
   await db.execute(sql`DELETE FROM organisations`);
+  await pg.end();
 });


### PR DESCRIPTION
## Description

This fixes an error where too many open connections postgres error could be encountered while running tests

## Additional Notes

N/A

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
