### PR TITLE
fix(Google): check 401 response status when verifying DWD scopes

### DIFF
--- a/apps/google/src/connectors/google/clients.ts
+++ b/apps/google/src/connectors/google/clients.ts
@@ -15,11 +15,15 @@ export const getGoogleServiceAccountClient = async (managerEmail: string, isAdmi
   if (isAdmin) {
     try {
       await client.authorize();
-    } catch (error) {
-      logger.error('Admin does not have the required privileges', { managerEmail });
-      throw new GoogleUnauthorizedError('Admin does not have the required privileges', {
-        cause: error,
-      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- error handling
+    } catch (error: any) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- error handling
+      if (error?.status === 401) {
+        logger.error('Admin does not have the required privileges', { managerEmail });
+        throw new GoogleUnauthorizedError('Admin does not have the required privileges', {
+          cause: error,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This fixes a bug where Google server wouldn't be able to handle some request sometimes, leading to triggering false Google unauthorized error which by consequence would remove the organisation and set a source connection error.

For now we verify that the status code is a 401 to remove this false positive, Google returning a 400 when unable to handle requests.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
