### PR TITLE
fix(design-system): update react dom canary types reference

### DIFF
--- a/packages/design-system/global.d.ts
+++ b/packages/design-system/global.d.ts
@@ -1,2 +1,0 @@
-// global.d.ts
-import 'react-dom/canary';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference types="react-dom/canary" />
+
 export * from './Alert';
 export * from './Button';
 export * from './Form';

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@elba-security/tsconfig/react-library.json",
-  "include": ["src", "./global.d.ts"],
+  "include": ["src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description

This fixes a bug where integration couldn't be built because reference to react-dom canary wasn't properly imported

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
