### PR TITLE
fix(Google): fix a bug where refreshing a deleted Google drive file was not properly handled

### DIFF
--- a/apps/google/src/connectors/google/files.ts
+++ b/apps/google/src/connectors/google/files.ts
@@ -18,18 +18,28 @@ export const getGoogleFile = async ({
   supportsAllDrives = true,
   ...getFileParams
 }: drive.Params$Resource$Files$Get) => {
-  const { data: googleFile } = await new drive.Drive({}).files.get({
-    ...getFileParams,
-    fields,
-    supportsAllDrives,
-  });
+  try {
+    const { data: googleFile } = await new drive.Drive({}).files.get({
+      ...getFileParams,
+      fields,
+      supportsAllDrives,
+    });
 
-  const result = googleFileSchema.safeParse(googleFile);
-  if (!result.success) {
-    throw new Error('Failed to parse Google file');
+    const result = googleFileSchema.safeParse(googleFile);
+    if (!result.success) {
+      throw new Error('Failed to parse Google file');
+    }
+
+    return result.data;
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Start of error handling */
+  } catch (error: any) {
+    if (error?.code === 404) {
+      /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- End of error handling */
+      return null;
+    }
+
+    throw error;
   }
-
-  return result.data;
 };
 
 export const listGoogleFiles = async ({

--- a/apps/google/src/inngest/functions/data-protection/refresh-object.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/refresh-object.test.ts
@@ -133,12 +133,7 @@ describe('refresh-data-protection-object', () => {
     const elba = spyOnElba();
     const serviceAccountClientSpy = spyOnGoogleServiceAccountClient();
 
-    vi.spyOn(googleFiles, 'getGoogleFile').mockImplementation(() => {
-      // eslint-disable-next-line prefer-promise-reject-errors -- this is a mock
-      return Promise.reject({
-        code: 404,
-      });
-    });
+    vi.spyOn(googleFiles, 'getGoogleFile').mockResolvedValue(null);
 
     vi.spyOn(googlePermissions, 'listAllGoogleFileNonInheritedPermissions');
 

--- a/packages/test-utils/src/inngest/function-mock.ts
+++ b/packages/test-utils/src/inngest/function-mock.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- needed for efficient type extraction */
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
-import type { InngestFunction, EventsFromOpts } from 'inngest';
+import { type InngestFunction, type EventsFromOpts, StepError } from 'inngest';
 
 type AnyInngestFunction = InngestFunction.Any;
 
@@ -55,9 +55,14 @@ export const createInngestFunctionMock =
   // @ts-expect-error -- this is a mock
   (data?: ExtractEvents<F>[EventName & string]['data']) => {
     const step = {
-      run: vi
-        .fn()
-        .mockImplementation((name: string, stepHandler: () => Promise<unknown>) => stepHandler()),
+      run: vi.fn().mockImplementation(async (name: string, stepHandler: () => Promise<unknown>) => {
+        try {
+          const result = await stepHandler();
+          return result;
+        } catch (error) {
+          throw new StepError(name, error);
+        }
+      }),
       sendEvent: vi.fn().mockResolvedValue(undefined),
       waitForEvent: vi.fn().mockResolvedValue(undefined),
       sleepUntil: vi.fn().mockResolvedValue(undefined),

--- a/packages/test-utils/src/inngest/function-mock.ts
+++ b/packages/test-utils/src/inngest/function-mock.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- needed for efficient type extraction */
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
-import { type InngestFunction, type EventsFromOpts, StepError } from 'inngest';
+import {
+  type InngestFunction,
+  type EventsFromOpts,
+  StepError,
+  NonRetriableError,
+  RetryAfterError,
+} from 'inngest';
 
 type AnyInngestFunction = InngestFunction.Any;
 
@@ -60,7 +66,11 @@ export const createInngestFunctionMock =
           const result = await stepHandler();
           return result;
         } catch (error) {
-          throw new StepError(name, error);
+          if (!(error instanceof NonRetriableError || error instanceof RetryAfterError)) {
+            throw new StepError(name, error);
+          }
+
+          throw error;
         }
       }),
       sendEvent: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description

This fixes an issue where deleted Google Drive files were not properly handled while refreshing an issue. This is because Inngest is wrapping errors from step with `StepError`. A solution would be to get the `cause` but Inngest StepError is not setting `cause` attribute: https://github.com/inngest/inngest-js/blob/28a8750239a68815d9c4ada32e0df1b434bf66de/packages/inngest/src/components/StepError.ts#L12

I also updated our mock inngest function util to throw StepError to avoid this error as well in our tests

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
