### PR TITLE
refactor(confluence): update objects url

### DIFF
--- a/apps/confluence/src/connectors/elba/data-protection/objects.ts
+++ b/apps/confluence/src/connectors/elba/data-protection/objects.ts
@@ -48,7 +48,7 @@ export const formatPageObject = (
   id: page.id,
   ownerId: page.ownerId,
   name: page.title,
-  url: `${options.instanceUrl}${page._links.webui}`,
+  url: `${options.instanceUrl}/wiki${page._links.webui}`,
   metadata: {
     objectType: 'page',
   } satisfies PageObjectMetadata,
@@ -107,7 +107,7 @@ export const formatSpaceObject = (
   id: space.id,
   ownerId: space.authorId,
   name: space.name,
-  url: `${options.instanceUrl}${space._links.webui}`,
+  url: `${options.instanceUrl}/wiki${space._links.webui}`,
   metadata: {
     objectType: 'space',
     key: space.key,

--- a/apps/confluence/src/inngest/functions/__mocks__/confluence-pages.ts
+++ b/apps/confluence/src/inngest/functions/__mocks__/confluence-pages.ts
@@ -44,7 +44,7 @@ export const pageWithRestrictions: ConfluencePageWithRestrictions = {
   id: 'page-id',
   title: 'page title',
   _links: {
-    webui: 'baz/biz',
+    webui: '/baz/biz',
   },
   spaceId: 'space-id',
   ownerId: 'owner-id',
@@ -160,5 +160,5 @@ export const pageWithRestrictionsObject: DataProtectionObject = {
       userId: 'app-id',
     },
   ],
-  url: 'http://foo.bar/baz/biz',
+  url: 'http://foo.bar/wiki/baz/biz',
 };

--- a/apps/confluence/src/inngest/functions/__mocks__/confluence-spaces.ts
+++ b/apps/confluence/src/inngest/functions/__mocks__/confluence-spaces.ts
@@ -69,7 +69,7 @@ export const spaceWithPermissions: ConfluenceSpaceWithPermissions = {
   authorId: 'author-id',
   type: 'global',
   _links: {
-    webui: 'baz/biz',
+    webui: '/baz/biz',
   },
   permissions: [...userPermissions, ...groupPermissions, ...anonymousPermissions],
 };
@@ -176,5 +176,5 @@ export const spaceWithPermissionsObject: DataProtectionObject = {
       userId: 'account-9',
     },
   ],
-  url: 'http://foo.bar/baz/biz',
+  url: 'http://foo.bar/wiki/baz/biz',
 };

--- a/apps/confluence/src/inngest/functions/__mocks__/organisations.ts
+++ b/apps/confluence/src/inngest/functions/__mocks__/organisations.ts
@@ -6,7 +6,7 @@ export const organisation = {
   id: `45a76301-f1dd-4a77-b12f-9d7d3fca3c90`,
   region: 'us',
   instanceId: '1234',
-  instanceUrl: 'http://foo.bar/',
+  instanceUrl: 'http://foo.bar',
   accessToken: await encrypt(accessToken),
   refreshToken: 'encrypted-refresh-token',
 };

--- a/apps/confluence/src/inngest/functions/data-protection/schedule-data-protection-syncs.test.ts
+++ b/apps/confluence/src/inngest/functions/data-protection/schedule-data-protection-syncs.test.ts
@@ -10,7 +10,7 @@ const organisations = Array.from({ length: 5 }, (_, i) => ({
   id: `45a76301-f1dd-4a77-b12f-9d7d3fca3c9${i}`,
   region: 'us',
   instanceId: '1234',
-  instanceUrl: 'http://foo.bar/',
+  instanceUrl: 'http://foo.bar',
   accessToken: 'test-access-token',
   refreshToken: 'test-access-token',
 }));

--- a/apps/confluence/src/inngest/functions/users/schedule-users-syncs.test.ts
+++ b/apps/confluence/src/inngest/functions/users/schedule-users-syncs.test.ts
@@ -10,7 +10,7 @@ const organisations = Array.from({ length: 5 }, (_, i) => ({
   id: `45a76301-f1dd-4a77-b12f-9d7d3fca3c9${i}`,
   region: 'us',
   instanceId: '1234',
-  instanceUrl: 'http://foo.bar/',
+  instanceUrl: 'http://foo.bar',
   accessToken: 'test-access-token',
   refreshToken: 'test-access-token',
 }));


### PR DESCRIPTION
## Description

confluence API changed and remove /wiki from objects url

- add `/wiki` in the data protection object url 

## Additional Notes

N/A

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.
