### PR TITLE
fix(github): fix github app settings url

### DIFF
--- a/apps/github/src/connectors/github/app.test.ts
+++ b/apps/github/src/connectors/github/app.test.ts
@@ -11,7 +11,6 @@ describe('app connector', () => {
     test('should return installation when installation is valid', async () => {
       const app = {
         name: 'foo',
-        html_url: 'http://github.com/foo',
         description: null,
         owner: null,
       };
@@ -34,9 +33,7 @@ describe('app connector', () => {
 
     test('should throw when installation is invalid', async () => {
       const app = {
-        name: 'foo',
-        // html_url should be defined
-        html_url: null,
+        name: null,
         description: null,
         owner: null,
       };

--- a/apps/github/src/connectors/github/app.ts
+++ b/apps/github/src/connectors/github/app.ts
@@ -3,7 +3,6 @@ import { createOctokitApp } from './commons/client';
 
 export const AppSchema = z.object({
   name: z.string(),
-  html_url: z.string(),
   description: z.string().nullable(),
   owner: z
     .object({

--- a/apps/github/src/connectors/github/organization.test.ts
+++ b/apps/github/src/connectors/github/organization.test.ts
@@ -31,6 +31,7 @@ const invalidMembers = [
 const validInstallations = Array.from({ length: 5 }, (_, i) => ({
   id: i,
   app_slug: `app-${i}`,
+  html_url: `http://foo.bar/${i}`,
   created_at: new Date().toISOString(),
   permissions: { foo: 'read', baz: 'write', biz: 'read' },
   suspended_at: null,

--- a/apps/github/src/connectors/github/organization.ts
+++ b/apps/github/src/connectors/github/organization.ts
@@ -110,6 +110,7 @@ const OrganizationInstallationSchema = z.object({
   created_at: z.string(),
   permissions: z.record(z.enum(['read', 'write'])),
   suspended_at: z.string().nullable(),
+  html_url: z.string(),
 });
 
 export type OrganizationInstallation = z.infer<typeof OrganizationInstallationSchema>;

--- a/apps/github/src/inngest/functions/third-party-apps/__mocks__/github.ts
+++ b/apps/github/src/inngest/functions/third-party-apps/__mocks__/github.ts
@@ -3,6 +3,7 @@
 export const githubInstallations = Array.from({ length: 5 }, (_, i) => ({
   id: 100 + i,
   created_at: '2023-12-06T15:02:11.538Z',
+  html_url: `http//foo.bar/${100 + i}`,
   app_slug: `app-${i}`,
   permissions: {
     foo: 'read' as const,
@@ -15,7 +16,6 @@ export const githubApps = githubInstallations.map(({ id, app_slug }) => ({
   name: `app-name-${id}`,
   app_slug,
   description: `app-description-${id}`,
-  html_url: `http//foo.bar/${id}`,
   owner: {
     name: `app-owner-${id}`,
   },

--- a/apps/github/src/inngest/functions/third-party-apps/sync-apps-page.ts
+++ b/apps/github/src/inngest/functions/third-party-apps/sync-apps-page.ts
@@ -22,7 +22,7 @@ const formatElbaApp = (
   const scopes = formatElbaAppScopes(installation.permissions);
   return {
     id: `${installation.id}`,
-    url: app.html_url,
+    url: installation.html_url,
     name: app.name,
     publisherName: app.owner?.name ?? undefined,
     description: app.description ?? undefined,


### PR DESCRIPTION
## Description

- use installation url as app url

## Additional Notes

Because sent apps to elba are unique to each installation this url will be unique for each organisation installation.
It redirect directly to the settings page of the app installation letting the admin uninstall the app.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.
