### PR TITLE
feat(zod): add zod package

### DIFF
--- a/apps/microsoft/package.json
+++ b/apps/microsoft/package.json
@@ -24,6 +24,7 @@
     "@elba-security/sdk": "workspace:*",
     "@elba-security/utils": "workspace:*",
     "@elba-security/design-system": "workspace:*",
+    "@elba-security/zod": "workspace:*",
     "@neondatabase/serverless": "0.9.0",
     "@sentry/nextjs": "^7.88.0",
     "@vercel/postgres": "0.5.1",

--- a/apps/microsoft/src/connectors/elba/third-party-apps/objects.ts
+++ b/apps/microsoft/src/connectors/elba/third-party-apps/objects.ts
@@ -1,16 +1,6 @@
 import type { ThirdPartyAppsObjectUser } from '@elba-security/sdk';
-import type {
-  MicrosoftAppPermission,
-  MicrosoftAppWithOauthGrants,
-} from '@/connectors/microsoft/apps';
+import type { MicrosoftAppWithOauthGrants } from '@/connectors/microsoft/apps';
 import type { AppUserMetadata } from './metadata';
-
-type ValidMicrosoftAppRolePermission = { id: string; principalId: string };
-
-const isValidAppRolePermission = (
-  appRole: MicrosoftAppPermission
-): appRole is ValidMicrosoftAppRolePermission =>
-  Boolean(appRole.principalId) && Boolean(appRole.id);
 
 const mergeScopes = (a: string[], b: string[]) =>
   [...a, ...b].filter((scope, i, scopes) => scopes.indexOf(scope) === i);
@@ -34,10 +24,6 @@ const formatAppUsers = (app: MicrosoftAppWithOauthGrants): ThirdPartyAppsObjectU
 
   // add users directly assigned to the app
   for (const appRole of app.appRoleAssignedTo) {
-    if (!isValidAppRolePermission(appRole)) {
-      continue;
-    }
-
     users.set(appRole.principalId, {
       id: appRole.principalId,
       scopes: app.oauth2PermissionScopes,

--- a/apps/microsoft/src/env.ts
+++ b/apps/microsoft/src/env.ts
@@ -1,16 +1,5 @@
+import { zInngestRetry } from '@elba-security/zod';
 import { z } from 'zod';
-
-const zEnvRetry = () =>
-  z
-    .unknown()
-    .transform((value) => {
-      if (typeof value === 'string') return Number(value);
-      return value;
-    })
-    .pipe(z.number().int().min(0).max(20))
-    .default(3) as unknown as z.ZodLiteral<
-    0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20
-  >;
 
 export const env = z
   .object({
@@ -31,16 +20,16 @@ export const env = z
     ENCRYPTION_KEY: z.string().min(1),
     DATABASE_URL: z.string().min(1),
     DATABASE_PROXY_PORT: z.coerce.number().int().positive().optional(),
-    REMOVE_ORGANISATION_MAX_RETRY: zEnvRetry(),
+    REMOVE_ORGANISATION_MAX_RETRY: zInngestRetry(),
     THIRD_PARTY_APPS_SYNC_CRON: z.string().default('0 0 * * *'),
     THIRD_PARTY_APPS_SYNC_BATCH_SIZE: z.coerce.number().positive().default(10),
-    THIRD_PARTY_APPS_SYNC_MAX_RETRY: zEnvRetry(),
-    THIRD_PARTY_APPS_REVOKE_APP_PERMISSION_MAX_RETRY: zEnvRetry(),
-    THIRD_PARTY_APPS_REFRESH_APP_PERMISSION_MAX_RETRY: zEnvRetry(),
-    TOKEN_REFRESH_MAX_RETRY: zEnvRetry(),
+    THIRD_PARTY_APPS_SYNC_MAX_RETRY: zInngestRetry(),
+    THIRD_PARTY_APPS_REVOKE_APP_PERMISSION_MAX_RETRY: zInngestRetry(),
+    THIRD_PARTY_APPS_REFRESH_APP_PERMISSION_MAX_RETRY: zInngestRetry(),
+    TOKEN_REFRESH_MAX_RETRY: zInngestRetry(),
     USERS_SYNC_CRON: z.string().default('0 0 * * *'),
     USERS_SYNC_BATCH_SIZE: z.coerce.number().int().positive().default(100),
-    USERS_SYNC_MAX_RETRY: zEnvRetry(),
+    USERS_SYNC_MAX_RETRY: zInngestRetry(),
     VERCEL_ENV: z.string().min(1).optional(),
   })
   .parse(process.env);

--- a/packages/zod/.eslintrc.json
+++ b/packages/zod/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@elba-security/custom/library"]
+}

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -1,0 +1,3 @@
+# `@elba-security/zod`
+
+Expose a collection of zod utils.

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@elba-security/zod",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "lint": "eslint src",
+    "test": "vitest run",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "typescript": "^5.3.3"
+  },
+  "devDependencies": {
+    "@elba-security/eslint-config-custom": "workspace:*",
+    "@elba-security/tsconfig": "workspace:*",
+    "eslint": "^8",
+    "typescript": "^5.3.3",
+    "vitest": "1.4.0",
+    "zod": "3.22.4"
+  },
+  "peerDependencies": {
+    "zod": ">=3.0.0"
+  }
+}

--- a/packages/zod/src/filtered-array.test.ts
+++ b/packages/zod/src/filtered-array.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import { ZodError, z } from 'zod';
+import { zFilteredArray } from './filtered-array';
+
+const schema = zFilteredArray(z.object({ id: z.string() }));
+
+const validItems = [{ id: '1' }, { id: '2' }];
+const invalidItems = ['10', null, undefined, true, { foo: 'bar' }];
+
+describe('zFilteredArray', () => {
+  test.each(invalidItems)('should return an error when data is $', (value) => {
+    const result = schema.safeParse(value);
+
+    expect(result.success).toBe(false);
+  });
+
+  test('should filter when data is an array', () => {
+    const result = schema.safeParse([...validItems, ...invalidItems]);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toStrictEqual(validItems);
+    }
+  });
+
+  test('should return an error when valid items are less than min', () => {
+    const result = zFilteredArray(z.object({ id: z.string() }), { min: 100 }).safeParse(validItems);
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ZodError);
+      expect(result.error.errors).toMatchObject([
+        {
+          code: 'too_small',
+          path: [],
+        },
+      ]);
+    }
+  });
+
+  test('should return an error when valid items are more than max', () => {
+    const result = zFilteredArray(z.object({ id: z.string() }), { max: 1 }).safeParse(validItems);
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ZodError);
+      expect(result.error.errors).toMatchObject([
+        {
+          code: 'too_big',
+          path: [],
+        },
+      ]);
+    }
+  });
+});

--- a/packages/zod/src/filtered-array.ts
+++ b/packages/zod/src/filtered-array.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { applyMinMax } from './utils';
+
+export type ZFilteredArrayParams = {
+  min?: number;
+  max?: number;
+};
+
+export const zFilteredArray = <T extends z.ZodTypeAny>(
+  schema: T,
+  params: ZFilteredArrayParams = {}
+) => {
+  return z.preprocess(
+    (data, ctx) => {
+      const result = z.array(z.unknown()).safeParse(data);
+      if (!result.success) {
+        result.error.issues.forEach(ctx.addIssue);
+        return null;
+      }
+
+      return result.data
+        .map((item) => (schema.safeParse(item).success ? (item as T) : undefined))
+        .filter((item): item is T => Boolean(item));
+    },
+    applyMinMax({ schema: z.array(schema), ...params })
+  );
+};

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,0 +1,3 @@
+export * from './filtered-array';
+export * from './inngest-retry';
+export * from './segregate';

--- a/packages/zod/src/inngest-retry.test.ts
+++ b/packages/zod/src/inngest-retry.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { zInngestRetry } from './inngest-retry';
+
+const schema = zInngestRetry();
+
+describe('zInngestRetry', () => {
+  test.each(['10', '0', 12, 0, 20, '20'])('should succeed when data is %j', (value) => {
+    const result = schema.safeParse(value);
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data).toBe(Number(value));
+    }
+  });
+
+  test.each(['-1', '21', '100'])('should fails when data is %j', (value) => {
+    const result = schema.safeParse(value);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/zod/src/inngest-retry.ts
+++ b/packages/zod/src/inngest-retry.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const zInngestRetry = (...params: Parameters<typeof z.number>) =>
+  z.coerce
+    .number(...params)
+    .int()
+    .min(0)
+    .max(20)
+    .optional()
+    .default(3) as unknown as z.ZodLiteral<
+    0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20
+  >;

--- a/packages/zod/src/segregate.test.ts
+++ b/packages/zod/src/segregate.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+import { ZodError, z } from 'zod';
+import type { ZSegregateParams } from './segregate';
+import { zSegregate } from './segregate';
+
+const schema = zSegregate(z.object({ id: z.string() }));
+const validItems = [{ id: 'id-1' }, { id: 'id-2', foo: 'bar' }];
+const invalidItems = [{}, false, undefined, { foo: 'bar' }];
+
+describe('zSegregate', () => {
+  test('should segregate valid and invalids items', () => {
+    const result = schema.safeParse([...validItems, ...invalidItems]);
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data).toStrictEqual({
+        valids: validItems.map(({ id }) => ({ id })),
+        invalids: invalidItems,
+      });
+    }
+  });
+
+  test('should return an error when the data is invalid', () => {
+    const result = schema.safeParse('an error');
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ZodError);
+      expect(result.error.errors).toMatchObject([
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          received: 'string',
+          path: [],
+          message: 'Expected array, received string',
+        },
+      ]);
+    }
+  });
+
+  test.each([
+    {
+      when: 'minValids value is not reached',
+      params: {
+        minValids: 1,
+      },
+      data: [],
+    },
+    {
+      when: 'minInvalids value is not reached',
+      params: {
+        minInvalids: 1,
+      },
+      data: [],
+    },
+    {
+      when: 'maxValids value is exceeded',
+      params: {
+        maxValids: 1,
+      },
+      data: [{ id: '1' }, { id: '2' }],
+    },
+    {
+      when: 'maxInvalids value is exceeded',
+      params: {
+        maxInvalids: 1,
+      },
+      data: [null, 'foo'],
+    },
+  ] satisfies { when: string; params: ZSegregateParams; data: unknown }[])(
+    `should return an error when $when`,
+    ({ params, data }) => {
+      const result = zSegregate(z.object({ id: z.string() }), params).safeParse(data);
+
+      expect(result.success).toBe(false);
+    }
+  );
+
+  test.each([
+    {
+      when: 'minValids value is reached',
+      params: {
+        minValids: 1,
+      },
+      data: [{ id: '1' }, { id: '2' }],
+    },
+    {
+      when: 'minInvalids value is reached',
+      params: {
+        minInvalids: 1,
+      },
+      data: [null],
+    },
+    {
+      when: 'maxValids value is not exceeded',
+      params: {
+        maxValids: 1,
+      },
+      data: [{ id: '1' }, null],
+    },
+    {
+      when: 'maxInvalids value is not exceeded',
+      params: {
+        maxInvalids: 1,
+      },
+      data: [null, { id: '1' }],
+    },
+  ] satisfies { when: string; params: ZSegregateParams; data: unknown }[])(
+    'should succeed when $when',
+    ({ params, data }) => {
+      const result = zSegregate(z.object({ id: z.string() }), params).safeParse(data);
+
+      expect(result.success).toBe(true);
+    }
+  );
+});

--- a/packages/zod/src/segregate.ts
+++ b/packages/zod/src/segregate.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { applyMinMax } from './utils';
+
+export type ZSegregateParams = {
+  minValids?: number;
+  minInvalids?: number;
+  maxValids?: number;
+  maxInvalids?: number;
+};
+
+export const zSegregate = <T extends z.ZodTypeAny>(schema: T, params: ZSegregateParams = {}) => {
+  const baseSchema = z.preprocess(
+    (data, ctx) => {
+      const result = z.array(z.unknown()).safeParse(data);
+      if (!result.success) {
+        result.error.issues.forEach(ctx.addIssue);
+        return null;
+      }
+      const valids: z.infer<T> = [];
+      const invalids: unknown[] = [];
+
+      for (const item of result.data) {
+        const itemResult = schema.safeParse(item);
+        if (itemResult.success) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- it's indeed a safe assignment
+          valids.push(itemResult.data);
+        } else {
+          invalids.push(item);
+        }
+      }
+
+      return { valids, invalids };
+    },
+    z.object({
+      valids: applyMinMax({
+        schema: z.array(schema),
+        min: params.minValids,
+        max: params.maxValids,
+      }),
+      invalids: applyMinMax({
+        schema: z.array(z.unknown()),
+        min: params.minInvalids,
+        max: params.maxInvalids,
+      }),
+    })
+  );
+
+  return baseSchema;
+};

--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -1,0 +1,18 @@
+import type { z } from 'zod';
+
+type ApplyMinMaxParams<T extends z.ZodTypeAny> = {
+  schema: z.ZodArray<T>;
+  min?: number;
+  max?: number;
+};
+
+export const applyMinMax = <T extends z.ZodTypeAny>({ schema, min, max }: ApplyMinMaxParams<T>) => {
+  let appliedSchema = schema;
+  if (min) {
+    appliedSchema = appliedSchema.min(min);
+  }
+  if (max) {
+    appliedSchema = appliedSchema.max(max);
+  }
+  return appliedSchema;
+};

--- a/packages/zod/tsconfig.json
+++ b/packages/zod/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@elba-security/tsconfig/base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/zod/vitest.config.mts
+++ b/packages/zod/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1265,6 +1265,9 @@ importers:
       '@elba-security/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@elba-security/zod':
+        specifier: workspace:*
+        version: link:../../packages/zod
       '@neondatabase/serverless':
         specifier: 0.9.0
         version: 0.9.0
@@ -2181,6 +2184,28 @@ importers:
       vitest:
         specifier: 1.4.0
         version: 1.4.0(@edge-runtime/vm@3.1.7)
+
+  packages/zod:
+    dependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
+    devDependencies:
+      '@elba-security/eslint-config-custom':
+        specifier: workspace:*
+        version: link:../eslint-config-custom
+      '@elba-security/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      eslint:
+        specifier: ^8
+        version: 8.53.0
+      vitest:
+        specifier: 1.4.0
+        version: 1.4.0(@edge-runtime/vm@3.1.7)
+      zod:
+        specifier: 3.22.4
+        version: 3.22.4
 
 packages:
 


### PR DESCRIPTION
## Description

- add zod package
  - `zInngestRetry`: schema that match inngest retry type
  - `zSegregate`:  schema builder that split array into `valids` & `invalids` entries
    - return an error only if the value is not array or valids / invalids length does not match given config
  - `zFilteredArray`: schema build that filter out array entries
    - return an error only if the value is not array or result array length does not match given config
 - implement zod package utils in `microsoft`

## Additional Notes

I am open to API changes + renaming (especially zSegregate that could be not explicit enough or not inclusive).
I would loved to have the ability to do stuff like `zFilteredArray().min(0)` but TS is a jerk and I could not make it work with zod.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.
