### PR TITLE
feat(sharepoint): sync and delete item permissions update

### DIFF
--- a/apps/sharepoint/src/connectors/microsoft/sharepoint/permissions.test.ts
+++ b/apps/sharepoint/src/connectors/microsoft/sharepoint/permissions.test.ts
@@ -18,12 +18,14 @@ const driveId = 'some-drive-id';
 const itemId = 'some-item-id';
 const permissionId = 'permission-id';
 
-const granteeSchema = z.object({
-  email: z.string().email(),
-});
-
 const dataSchema = z.object({
-  grantees: z.array(granteeSchema).min(1),
+  grantees: z
+    .array(
+      z.object({
+        email: z.string(),
+      })
+    )
+    .min(1),
 });
 
 const permissions: MicrosoftDriveItemPermission[] = Array.from({ length: 5 }, (_, i) => ({

--- a/apps/sharepoint/src/connectors/microsoft/sharepoint/permissions.test.ts
+++ b/apps/sharepoint/src/connectors/microsoft/sharepoint/permissions.test.ts
@@ -407,4 +407,113 @@ describe('permissions connector', () => {
       ).rejects.toBeInstanceOf(MicrosoftError);
     });
   });
+
+  describe('getPermissionDetails', () => {
+    // mock token API endpoint using msw
+    beforeEach(() => {
+      server.use(
+        http.get(
+          `${env.MICROSOFT_API_URL}/sites/:siteId/drives/:driveId/items/:itemId/permissions/:permissionId`,
+          ({ request, params }) => {
+            if (
+              request.headers.get('Authorization') !== `Bearer ${validToken}` ||
+              params.siteId !== siteId ||
+              params.driveId !== driveId ||
+              params.permissionId !== permissionId
+            ) {
+              return new Response(undefined, { status: 401 });
+            } else if (params.itemId !== itemId) {
+              return new Response(undefined, { status: 404 });
+            }
+
+            return Response.json({ ...permissions[0] });
+          }
+        )
+      );
+    });
+
+    test('should resolves when the token and data is valid', () => {
+      expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: validToken,
+          siteId,
+          driveId,
+          itemId,
+          permissionId,
+        })
+      ).resolves;
+    });
+
+    test('should throws when the token is invalid', async () => {
+      await expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: 'invalid-token',
+          siteId,
+          driveId,
+          itemId,
+          permissionId,
+        })
+      ).rejects.toBeInstanceOf(MicrosoftError);
+    });
+
+    test('should throws when the siteId is invalid', async () => {
+      await expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: validToken,
+          siteId: 'invalid-siteId',
+          driveId,
+          itemId,
+          permissionId,
+        })
+      ).rejects.toBeInstanceOf(MicrosoftError);
+    });
+
+    test('should throws when the driveId is invalid', async () => {
+      await expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: validToken,
+          siteId,
+          driveId: 'invalid-driveId',
+          itemId,
+          permissionId,
+        })
+      ).rejects.toBeInstanceOf(MicrosoftError);
+    });
+
+    test('should throws when the itemId is invalid', async () => {
+      await expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: validToken,
+          siteId,
+          driveId,
+          itemId: 'invalid-itemId',
+          permissionId,
+        })
+      ).rejects.toBeInstanceOf(MicrosoftError);
+    });
+
+    test('should throws when the permissionId is invalid', async () => {
+      await expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: validToken,
+          siteId,
+          driveId,
+          itemId,
+          permissionId: 'invalid-permission-id',
+        })
+      ).rejects.toBeInstanceOf(MicrosoftError);
+    });
+
+    test('should ', async () => {
+      await expect(
+        getPermissionsConnector.getPermissionDetails({
+          token: validToken,
+          siteId,
+          driveId,
+          itemId,
+          permissionId,
+        })
+      ).resolves.toStrictEqual({ ...permissions[0] });
+    });
+  });
 });

--- a/apps/sharepoint/src/connectors/microsoft/sharepoint/permissions.ts
+++ b/apps/sharepoint/src/connectors/microsoft/sharepoint/permissions.ts
@@ -103,6 +103,10 @@ type DeleteItemPermissionParams = GetPermissionsParams & {
   permissionId: string;
 };
 
+type RevokeUserFromLinkPermissionParams = DeleteItemPermissionParams & {
+  userEmails: string[];
+};
+
 export type MicrosoftDriveItemPermission = z.infer<typeof basePSchema>;
 
 export const getAllItemPermissions = async ({
@@ -196,5 +200,33 @@ export const deleteItemPermission = async ({
 
   if (!response.ok) {
     throw new MicrosoftError('Could not delete permission', { response });
+  }
+};
+
+export const revokeUserFromLinkPermission = async ({
+  token,
+  siteId,
+  driveId,
+  itemId,
+  permissionId,
+  userEmails,
+}: RevokeUserFromLinkPermissionParams): Promise<void> => {
+  const url = new URL(
+    `https://graph.microsoft.com/beta/sites/${siteId}/drives/${driveId}/items/${itemId}/permissions/${permissionId}/revokeGrants`
+  );
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      grantees: userEmails.map((email) => ({ email })),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new MicrosoftError('Could not revoke permission', { response });
   }
 };

--- a/apps/sharepoint/src/inngest/client.ts
+++ b/apps/sharepoint/src/inngest/client.ts
@@ -2,6 +2,7 @@ import { EventSchemas, Inngest } from 'inngest';
 import { sentryMiddleware } from '@elba-security/inngest';
 import { logger } from '@elba-security/logger';
 import { rateLimitMiddleware } from './middlewares/rate-limit-middleware';
+import type { CombinedPermission } from './functions/data-protection/common/types';
 
 export const inngest = new Inngest({
   id: 'sharepoint',
@@ -96,7 +97,7 @@ export const inngest = new Inngest({
           siteId: string;
           driveId: string;
         };
-        permissions: string[];
+        permissions: CombinedPermission[];
       };
     };
     'sharepoint/drives.subscription.triggered': {

--- a/apps/sharepoint/src/inngest/functions/data-protection/common/helpers.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/common/helpers.ts
@@ -86,6 +86,8 @@ export const combinePermisisons = (
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- will be there
         const combinedItem = combinedPermissions.get(elbaPermissionId)!;
         if (combinedItem.type === 'user') {
+          // It's not obvious here, but the Item can have only one direct permission,
+          // so here we are only setting permission.id if combinedItem was created before (with links permissions)
           combinedItem.metadata.directPermissionId = permission.id;
         }
       }
@@ -118,7 +120,9 @@ export const combinePermisisons = (
         } else {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- will be there
           const combinedItem = combinedPermissions.get(elbaPermissionId)!;
-          if (combinedItem.type === 'user' && combinedItem.metadata.linksPermissionIds) {
+          if (combinedItem.type === 'user') {
+            combinedItem.metadata.linksPermissionIds =
+              combinedItem.metadata.linksPermissionIds ?? [];
             combinedItem.metadata.linksPermissionIds.push(permission.id);
           }
         }

--- a/apps/sharepoint/src/inngest/functions/data-protection/common/types.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/common/types.ts
@@ -21,3 +21,35 @@ export type ItemsWithPermissionsParsed = {
   toDelete: string[];
   toUpdate: ItemsWithPermissions[];
 };
+
+export type CombinedPermission =
+  | {
+      id: string;
+      type: 'user';
+      email: string;
+      metadata: {
+        email: string;
+        linksPermissionIds?: string[];
+        directPermissionId?: string;
+      };
+    }
+  | {
+      id: string;
+      type: 'anyone';
+    };
+
+export type CombinedLinkPermissions = {
+  permissionId: string;
+  userEmails?: string[];
+};
+
+export type PermissionDeletionResult = CombinedLinkPermissions & {
+  siteId: string;
+  driveId: string;
+  itemId: string;
+  status?: number;
+};
+
+export type DeleteItemFunctionParams = PermissionDeletionResult & {
+  token: string;
+};

--- a/apps/sharepoint/src/inngest/functions/data-protection/delete-item-permissions.test.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/delete-item-permissions.test.ts
@@ -7,14 +7,33 @@ import { db } from '@/database/client';
 import { MicrosoftError } from '@/common/error';
 import * as deleteItemPermissionConnector from '@/connectors/microsoft/sharepoint/permissions';
 import { deleteDataProtectionItemPermissions } from './delete-item-permissions';
+import type { CombinedLinkPermissions, CombinedPermission } from './common/types';
+import { preparePermissionDeletionArray } from './common/helpers';
 
 const token = 'test-token';
 
 const siteId = 'some-site-id';
 const driveId = 'some-drive-id';
 const itemId = 'some-item-id';
-const notFoundPermissionId = 'not-found-permission-id';
-const unexpectedFailedPermissionId = 'unexpected-failed-permission-id';
+const notFoundPermission: CombinedPermission = {
+  id: `some-not-found-permission-id`,
+  type: 'user',
+  email: `user-email-14454@someemail.com`,
+  metadata: {
+    email: `user-email-14454@someemail.com`,
+    directPermissionId: `some-not-found-permission-id`,
+  },
+};
+
+const unexpectedFailedPermission: CombinedPermission = {
+  id: `some-unexpected-failed-permission-id`,
+  type: 'user',
+  email: `user-email-14454@someemail.com`,
+  metadata: {
+    email: `user-email-14454@someemail.com`,
+    directPermissionId: `some-unexpected-failed-permission-id`,
+  },
+};
 
 const organisation = {
   id: '45a76301-f1dd-4a77-b12f-9d7d3fca3c90',
@@ -23,9 +42,32 @@ const organisation = {
   region: 'us',
 };
 
-const permissions: string[] = Array.from({ length: 5 }, (_, i) => `some-permission-id-${i}`);
+const count = 5;
 
-const permissionArray = [...permissions, notFoundPermissionId, unexpectedFailedPermissionId];
+const permissions: CombinedPermission[] = Array.from({ length: count }, (_, i) => {
+  if (i === 1)
+    return {
+      id: `some-random-id-${i}`,
+      type: 'anyone',
+    };
+
+  return {
+    id: `some-random-id-${i}`,
+    type: 'user',
+    email: `user-email-${i}@someemail.com`,
+    metadata: {
+      email: `user-email-${i}@someemail.com`,
+      linksPermissionIds: [
+        `user-email-${i}@someemail.com`,
+        `user-email-${i * 1000}@someemail.com`,
+        `user-email-${i * 10000}@someemail.com`,
+      ],
+      directPermissionId: `some-random-id-${i}`,
+    },
+  };
+});
+
+const failedPermissionArray = [notFoundPermission, unexpectedFailedPermission];
 
 const setupData = {
   id: itemId,
@@ -49,6 +91,7 @@ describe('delete-object', () => {
 
   test('should abort deletation when organisation is not registered', async () => {
     vi.spyOn(deleteItemPermissionConnector, 'deleteItemPermission').mockResolvedValue();
+    vi.spyOn(deleteItemPermissionConnector, 'revokeUserFromLinkPermission').mockResolvedValue();
 
     const [result, { step }] = setup({
       ...setupData,
@@ -59,79 +102,141 @@ describe('delete-object', () => {
 
     expect(step.run).toBeCalledTimes(0);
     expect(deleteItemPermissionConnector.deleteItemPermission).toBeCalledTimes(0);
+    expect(deleteItemPermissionConnector.revokeUserFromLinkPermission).toBeCalledTimes(0);
   });
 
   test('should delete object when item exists and return deleted permissions', async () => {
     vi.spyOn(deleteItemPermissionConnector, 'deleteItemPermission').mockResolvedValue();
+    vi.spyOn(deleteItemPermissionConnector, 'revokeUserFromLinkPermission').mockResolvedValue();
 
     const [result, { step }] = setup(setupData);
 
+    const permissionDeletionArray = preparePermissionDeletionArray(permissions);
+
     await expect(result).resolves.toStrictEqual({
-      deletedPermissions: permissions,
+      deletedPermissions: permissionDeletionArray.map((el) => ({
+        siteId,
+        driveId,
+        itemId,
+        status: 204,
+        userEmails: undefined,
+        ...el,
+      })),
       notFoundPermissions: [],
       unexpectedFailedPermissions: [],
     });
 
-    expect(step.run).toBeCalledTimes(permissions.length);
-    expect(deleteItemPermissionConnector.deleteItemPermission).toBeCalledTimes(permissions.length);
+    expect(step.run).toBeCalledTimes(permissionDeletionArray.length);
 
-    for (let i = 0; i < permissions.length; i++) {
-      const permissionId = permissions[i];
+    const { revokeUserFromLinkPermissions, deleteItemPermissions } =
+      permissionDeletionArray.reduce<{
+        revokeUserFromLinkPermissions: CombinedLinkPermissions[];
+        deleteItemPermissions: CombinedLinkPermissions[];
+      }>(
+        (acc, el) => {
+          if (el.userEmails?.length) acc.revokeUserFromLinkPermissions.push(el);
+          else acc.deleteItemPermissions.push(el);
+
+          return acc;
+        },
+        { revokeUserFromLinkPermissions: [], deleteItemPermissions: [] }
+      );
+
+    expect(deleteItemPermissionConnector.deleteItemPermission).toBeCalledTimes(
+      deleteItemPermissions.length
+    );
+    expect(deleteItemPermissionConnector.revokeUserFromLinkPermission).toBeCalledTimes(
+      revokeUserFromLinkPermissions.length
+    );
+
+    for (let i = 0; i < deleteItemPermissions.length; i++) {
+      const permission = deleteItemPermissions[i];
       expect(deleteItemPermissionConnector.deleteItemPermission).nthCalledWith(i + 1, {
         token,
         itemId,
         siteId,
         driveId,
-        permissionId,
+        permissionId: permission?.permissionId,
+      });
+    }
+
+    for (let i = 0; i < revokeUserFromLinkPermissions.length; i++) {
+      const permission = revokeUserFromLinkPermissions[i];
+      expect(deleteItemPermissionConnector.revokeUserFromLinkPermission).nthCalledWith(i + 1, {
+        token,
+        itemId,
+        siteId,
+        driveId,
+        permissionId: permission?.permissionId,
+        userEmails: permission?.userEmails,
       });
     }
   });
 
-  test('should delete object when item exists and return deleted permissions and not found permission', async () => {
+  test('should not found permission and unexpected failed permission', async () => {
     vi.spyOn(deleteItemPermissionConnector, 'deleteItemPermission').mockImplementation(
       ({ permissionId }) => {
-        if (permissionId === notFoundPermissionId) {
+        if (permissionId === notFoundPermission.metadata.directPermissionId) {
           return Promise.reject(
             new MicrosoftError('Could not delete item permission', {
               response: new Response(undefined, { status: 404 }),
             })
           );
         }
-        if (permissionId === unexpectedFailedPermissionId) {
+        if (permissionId === unexpectedFailedPermission.metadata.directPermissionId) {
           return Promise.reject(
             new MicrosoftError('Could not delete item permission', {
-              response: new Response(undefined, { status: 403 }),
+              response: new Response(undefined, { status: 500 }),
             })
           );
         }
         return Promise.resolve();
       }
     );
+    vi.spyOn(deleteItemPermissionConnector, 'revokeUserFromLinkPermission').mockResolvedValue();
 
     const [result, { step }] = setup({
       ...setupData,
-      permissions: permissionArray,
+      permissions: failedPermissionArray,
     });
 
     await expect(result).resolves.toStrictEqual({
-      deletedPermissions: permissions,
-      notFoundPermissions: [notFoundPermissionId],
-      unexpectedFailedPermissions: [unexpectedFailedPermissionId],
+      deletedPermissions: [],
+      notFoundPermissions: [
+        {
+          siteId,
+          driveId,
+          itemId,
+          status: 404,
+          userEmails: undefined,
+          permissionId: notFoundPermission.metadata.directPermissionId,
+        },
+      ],
+      unexpectedFailedPermissions: [
+        {
+          siteId,
+          driveId,
+          itemId,
+          status: 500,
+          userEmails: undefined,
+          permissionId: unexpectedFailedPermission.metadata.directPermissionId,
+        },
+      ],
     });
 
-    expect(step.run).toBeCalledTimes(permissionArray.length);
+    expect(step.run).toBeCalledTimes(failedPermissionArray.length);
     expect(deleteItemPermissionConnector.deleteItemPermission).toBeCalledTimes(
-      permissionArray.length
+      failedPermissionArray.length
     );
 
-    for (let i = 0; i < permissionArray.length; i++) {
-      const permissionId = permissionArray[i];
+    for (let i = 0; i < failedPermissionArray.length; i++) {
+      const permission = failedPermissionArray[i];
       expect(deleteItemPermissionConnector.deleteItemPermission).nthCalledWith(i + 1, {
         token,
         itemId,
         siteId,
         driveId,
-        permissionId,
+        permissionId: permission?.metadata.directPermissionId,
       });
     }
   });

--- a/apps/sharepoint/src/inngest/functions/data-protection/delete-item-permissions.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/delete-item-permissions.ts
@@ -28,7 +28,7 @@ export const deleteDataProtectionItemPermissions = inngest.createFunction(
         match: 'data.organisationId',
       },
     ],
-    retries: 2,
+    retries: 5,
   },
   { event: 'sharepoint/data_protection.delete_object_permissions.requested' },
   async ({ event, step }) => {

--- a/apps/sharepoint/src/inngest/functions/data-protection/refresh-item.test.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/refresh-item.test.ts
@@ -42,27 +42,45 @@ const item: MicrosoftDriveItem = {
   lastModifiedDateTime: '2024-02-23T15:50:09Z',
 };
 
-const permissions: MicrosoftDriveItemPermission[] = Array.from({ length: 10 }, (_, i) => ({
-  id: `permission-id-${i}`,
-  roles: ['write'],
-  link: { scope: 'users' },
-  grantedToV2: {
-    user: {
-      displayName: `some-display-name-${i}`,
-      id: `some-user-id-${i}`,
-      email: `some-user-email-${i}`,
-    },
-  },
-  grantedToIdentitiesV2: [
-    {
-      user: {
-        displayName: `some-display-name-${i}`,
-        id: `some-user-id-${i}`,
-        email: `some-user-email-${i}`,
+const permissions: MicrosoftDriveItemPermission[] = Array.from({ length: 10 }, (_, i) => {
+  if (i === 0 || i < 2) {
+    return {
+      id: `permission-id-${i}`,
+      roles: ['write'],
+      grantedToV2: {
+        user: {
+          displayName: `some-display-name-${i}`,
+          id: `some-user-id-${i}`,
+          email: `user-email-${i}@someemail.com`,
+        },
       },
-    },
-  ],
-}));
+    };
+  }
+
+  if (i === 2) {
+    return {
+      id: `permission-id-${i}`,
+      roles: ['write'],
+      link: { scope: 'anonymous' },
+      grantedToIdentitiesV2: [],
+    };
+  }
+
+  return {
+    id: `permission-id-${i}`,
+    roles: ['write'],
+    link: { scope: 'users' },
+    grantedToIdentitiesV2: [
+      {
+        user: {
+          displayName: `some-display-name-${i}`,
+          id: `some-user-id-${i}`,
+          email: `user-email-${i}@someemail.com`,
+        },
+      },
+    ],
+  };
+});
 
 const setupData = {
   id: itemId,

--- a/apps/sharepoint/src/inngest/functions/data-protection/sync-items.test.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/sync-items.test.ts
@@ -61,27 +61,45 @@ const groupedItems: MicrosoftDriveItem[] = Array.from({ length: itemsCount }, (_
 });
 
 const mockPermissions = (itemCount: number): MicrosoftDriveItemPermission[] => {
-  return Array.from({ length: itemCount }, (_, i) => ({
-    id: `permission-id-${i}`,
-    roles: ['write'],
-    link: { scope: 'users' },
-    grantedToV2: {
-      user: {
-        displayName: `some-display-name-${i}`,
-        id: `some-user-id-${i}`,
-        email: `some-user-email-${i}`,
-      },
-    },
-    grantedToIdentitiesV2: [
-      {
-        user: {
-          displayName: `some-display-name-${i}`,
-          id: `some-user-id-${i}`,
-          email: `some-user-email-${i}`,
+  return Array.from({ length: itemCount }, (_, i) => {
+    if (i === 0 || i < 2) {
+      return {
+        id: `permission-id-${i}`,
+        roles: ['write'],
+        grantedToV2: {
+          user: {
+            displayName: `some-display-name-${i}`,
+            id: `some-user-id-${i}`,
+            email: `user-email-${i}@someemail.com`,
+          },
         },
-      },
-    ],
-  }));
+      };
+    }
+
+    if (i === 2) {
+      return {
+        id: `permission-id-${i}`,
+        roles: ['write'],
+        link: { scope: 'anonymous' },
+        grantedToIdentitiesV2: [],
+      };
+    }
+
+    return {
+      id: `permission-id-${i}`,
+      roles: ['write'],
+      link: { scope: 'users' },
+      grantedToIdentitiesV2: [
+        {
+          user: {
+            displayName: `some-display-name-${i}`,
+            id: `some-user-id-${i}`,
+            email: `user-email-${i}@someemail.com`,
+          },
+        },
+      ],
+    };
+  });
 };
 
 const setupData = {

--- a/apps/sharepoint/src/inngest/functions/data-protection/update-items.test.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/update-items.test.ts
@@ -81,27 +81,45 @@ const items: Delta[] = Array.from({ length: itemLength }, (_, i) => {
 });
 
 const mockPermissions = (itemCount: number): MicrosoftDriveItemPermission[] => {
-  return Array.from({ length: itemCount }, (_, i) => ({
-    id: `permission-id-${i}`,
-    roles: ['write'],
-    link: { scope: 'users' },
-    grantedToV2: {
-      user: {
-        displayName: `some-display-name-${i}`,
-        id: `some-user-id-${i}`,
-        email: `some-user-email-${i}`,
-      },
-    },
-    grantedToIdentitiesV2: [
-      {
-        user: {
-          displayName: `some-display-name-${i}`,
-          id: `some-user-id-${i}`,
-          email: `some-user-email-${i}`,
+  return Array.from({ length: itemCount }, (_, i) => {
+    if (i === 0 || i < 2) {
+      return {
+        id: `permission-id-${i}`,
+        roles: ['write'],
+        grantedToV2: {
+          user: {
+            displayName: `some-display-name-${i}`,
+            id: `some-user-id-${i}`,
+            email: `user-email-${i}@someemail.com`,
+          },
         },
-      },
-    ],
-  }));
+      };
+    }
+
+    if (i === 2) {
+      return {
+        id: `permission-id-${i}`,
+        roles: ['write'],
+        link: { scope: 'anonymous' },
+        grantedToIdentitiesV2: [],
+      };
+    }
+
+    return {
+      id: `permission-id-${i}`,
+      roles: ['write'],
+      link: { scope: 'users' },
+      grantedToIdentitiesV2: [
+        {
+          user: {
+            displayName: `some-display-name-${i}`,
+            id: `some-user-id-${i}`,
+            email: `user-email-${i}@someemail.com`,
+          },
+        },
+      ],
+    };
+  });
 };
 
 const setupData = {


### PR DESCRIPTION
## Description

Sync Item logic update, now permissions combined to one user-permissions instance, also delete item permissions logic updated.

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
