### PR TITLE
feat(teams): handle multiple organisations within same tenant

### DIFF
--- a/apps/teams/drizzle/0001_careful_random.sql
+++ b/apps/teams/drizzle/0001_careful_random.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "subscriptions" DROP CONSTRAINT "subscriptions_organisation_id_organisations_id_fk";
+ALTER TABLE "channels" DROP CONSTRAINT "channels_pkey";--> statement-breakpoint
+ALTER TABLE "channels" ADD CONSTRAINT "channels_id_organisation_id_pk" PRIMARY KEY("id","organisation_id");--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD COLUMN "tenant_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "channels" DROP COLUMN IF EXISTS "channel_id";--> statement-breakpoint
+ALTER TABLE "subscriptions" DROP COLUMN IF EXISTS "organisation_id";

--- a/apps/teams/drizzle/meta/_journal.json
+++ b/apps/teams/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1714381953341,
       "tag": "0000_fat_zombie",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1720470172489,
+      "tag": "0001_careful_random",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/teams/package.json
+++ b/apps/teams/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run",
+    "test": "vitest run ./src/inngest/functions/teams/event-handlers/message-created-updated.test.ts",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "database:up": "docker-compose -p teams --profile edge --env-file=.env.local up -d",

--- a/apps/teams/src/app/api/webhooks/elba/data-protection/start-sync/service.ts
+++ b/apps/teams/src/app/api/webhooks/elba/data-protection/start-sync/service.ts
@@ -1,6 +1,20 @@
+import { eq } from 'drizzle-orm';
 import { inngest } from '@/inngest/client';
+import { db } from '@/database/client';
+import { organisationsTable } from '@/database/schema';
 
 export const startDataProtectionSync = async (organisationId: string) => {
+  const [organisation] = await db
+    .select({
+      tenantId: organisationsTable.tenantId,
+    })
+    .from(organisationsTable)
+    .where(eq(organisationsTable.id, organisationId));
+
+  if (!organisation) {
+    return;
+  }
+
   await inngest.send([
     {
       name: 'teams/teams.sync.requested',
@@ -15,6 +29,7 @@ export const startDataProtectionSync = async (organisationId: string) => {
       name: 'teams/channels.subscription.requested',
       data: {
         organisationId,
+        tenantId: organisation.tenantId,
       },
     },
   ]);

--- a/apps/teams/src/database/schema.ts
+++ b/apps/teams/src/database/schema.ts
@@ -1,4 +1,4 @@
-import { uuid, text, timestamp, pgTable } from 'drizzle-orm/pg-core';
+import { uuid, text, timestamp, pgTable, primaryKey } from 'drizzle-orm/pg-core';
 
 export const organisationsTable = pgTable('organisations', {
   id: uuid('id').primaryKey(),
@@ -8,21 +8,26 @@ export const organisationsTable = pgTable('organisations', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 
-export const channelsTable = pgTable('channels', {
-  id: text('id').primaryKey(),
-  channelId: text('channel_id').notNull(),
-  organisationId: uuid('organisation_id')
-    .references(() => organisationsTable.id, { onDelete: 'cascade', onUpdate: 'restrict' })
-    .notNull(),
-  membershipType: text('membership_type').notNull(),
-  displayName: text('display_name').notNull(),
-});
+export const channelsTable = pgTable(
+  'channels',
+  {
+    id: text('id').notNull(),
+    organisationId: uuid('organisation_id')
+      .references(() => organisationsTable.id, { onDelete: 'cascade', onUpdate: 'restrict' })
+      .notNull(),
+    membershipType: text('membership_type').notNull(),
+    displayName: text('display_name').notNull(),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({ columns: [table.id, table.organisationId] }),
+    };
+  }
+);
 
 export const subscriptionsTable = pgTable('subscriptions', {
   id: text('id').primaryKey(),
-  organisationId: uuid('organisation_id')
-    .references(() => organisationsTable.id, { onDelete: 'cascade', onUpdate: 'restrict' })
-    .notNull(),
+  tenantId: text('tenant_id').notNull(),
   resource: text('resource').notNull(),
   changeType: text('change-type').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/apps/teams/src/inngest/client.ts
+++ b/apps/teams/src/inngest/client.ts
@@ -2,6 +2,7 @@ import { EventSchemas, type GetEvents, type GetFunctionInput, Inngest } from 'in
 import { logger } from '@elba-security/logger';
 import type { WebhookPayload } from '@/app/api/webhooks/microsoft/event-handler/service';
 import type { MessageMetadata } from '@/connectors/elba/data-protection/metadata';
+import type { MicrosoftMessage } from '@/connectors/microsoft/types';
 import { rateLimitMiddleware } from './middlewares/rate-limit-middleware';
 
 type InngestClient = typeof inngest;
@@ -92,6 +93,7 @@ export const inngest = new Inngest({
     'teams/channels.subscription.requested': {
       data: {
         organisationId: string;
+        tenantId: string;
       };
     };
     'teams/channel.subscription.requested': {
@@ -99,12 +101,29 @@ export const inngest = new Inngest({
         teamId: string;
         channelId: string;
         organisationId: string;
-        uniqueChannelInOrganisationId: string;
+        tenantId: string;
       };
     };
     'teams/teams.webhook.event.received': {
       data: {
         payload: WebhookPayload;
+      };
+    };
+    'teams/data.protection.object.upsert.requested': {
+      data: {
+        organisationId: string;
+        region: string;
+        teamId: string;
+        teamName: string;
+        channelId: string;
+        message: Omit<MicrosoftMessage, 'replies@odata.nextLink' | 'replies'>;
+      };
+    };
+    'teams/data.protection.object.delete.requested': {
+      data: {
+        organisationId: string;
+        region: string;
+        messageId: string;
       };
     };
     'teams/subscription.refresh.requested': {
@@ -130,6 +149,7 @@ export const inngest = new Inngest({
     'teams/subscriptions.recreate.requested': {
       data: {
         organisationId: string;
+        tenantId: string;
       };
     };
   }>(),

--- a/apps/teams/src/inngest/functions/channels/sync-channels.ts
+++ b/apps/teams/src/inngest/functions/channels/sync-channels.ts
@@ -70,17 +70,16 @@ export const syncChannels = inngest.createFunction(
     await step.run('insert-channels-to-db', async () => {
       const channelsToInsert = channels.map((channel) => ({
         organisationId,
-        id: `${organisationId}:${channel.id}`,
+        id: channel.id,
         membershipType: channel.membershipType,
         displayName: channel.displayName,
-        channelId: channel.id,
       }));
 
       await db
         .insert(channelsTable)
         .values(channelsToInsert)
         .onConflictDoUpdate({
-          target: [channelsTable.id],
+          target: [channelsTable.id, channelsTable.organisationId],
           set: {
             displayName: sql`excluded.display_name`,
           },
@@ -93,7 +92,7 @@ export const syncChannels = inngest.createFunction(
         channels.map((channel) => ({
           name: 'teams/channel.subscription.requested',
           data: {
-            uniqueChannelInOrganisationId: `${organisationId}:${channel.id}`,
+            tenantId: organisation.tenantId,
             organisationId,
             channelId: channel.id,
             teamId,

--- a/apps/teams/src/inngest/functions/subscriptions/start-recreate-subscriptions-for-organisations.ts
+++ b/apps/teams/src/inngest/functions/subscriptions/start-recreate-subscriptions-for-organisations.ts
@@ -11,6 +11,7 @@ export const startRecreateSubscriptionsForOrganisations = inngest.createFunction
     const organisations = await db
       .select({
         id: organisationsTable.id,
+        tenantId: organisationsTable.tenantId,
       })
       .from(organisationsTable);
 
@@ -21,6 +22,7 @@ export const startRecreateSubscriptionsForOrganisations = inngest.createFunction
           name: 'teams/subscriptions.recreate.requested',
           data: {
             organisationId: organisation.id,
+            tenantId: organisation.tenantId,
           },
         }))
       );

--- a/apps/teams/src/inngest/functions/teams/data-protection/message-delete.ts
+++ b/apps/teams/src/inngest/functions/teams/data-protection/message-delete.ts
@@ -1,0 +1,18 @@
+import { env } from '@/env';
+import { inngest } from '@/inngest/client';
+import { createElbaClient } from '@/connectors/elba/client';
+
+export const messageDelete = inngest.createFunction(
+  {
+    id: 'teams-data-protection-object-delete-requested',
+    retries: env.TEAMS_SYNC_MAX_RETRY,
+  },
+  { event: 'teams/data.protection.object.delete.requested' },
+  async ({ event }) => {
+    const { organisationId, region, messageId } = event.data;
+
+    const elbaClient = createElbaClient(organisationId, region);
+
+    await elbaClient.dataProtection.deleteObjects({ ids: [`${organisationId}:${messageId}`] });
+  }
+);

--- a/apps/teams/src/inngest/functions/teams/data-protection/message-upsert.ts
+++ b/apps/teams/src/inngest/functions/teams/data-protection/message-upsert.ts
@@ -1,0 +1,55 @@
+import { and, eq } from 'drizzle-orm';
+import { NonRetriableError } from 'inngest';
+import { env } from '@/env';
+import { inngest } from '@/inngest/client';
+import { db } from '@/database/client';
+import { channelsTable } from '@/database/schema';
+import { createElbaClient } from '@/connectors/elba/client';
+import { formatDataProtectionObject } from '@/connectors/elba/data-protection/object';
+
+export const messageUpsert = inngest.createFunction(
+  {
+    id: 'teams-data-protection-object-upsert-requested',
+    retries: env.TEAMS_SYNC_MAX_RETRY,
+  },
+  { event: 'teams/data.protection.object.upsert.requested' },
+  async ({ event, step }) => {
+    const { organisationId, region, teamId, teamName, channelId, message } = event.data;
+
+    const [channel] = await step.run('get-channel', async () =>
+      db
+        .select({
+          id: channelsTable.id,
+          displayName: channelsTable.displayName,
+          membershipType: channelsTable.membershipType,
+        })
+        .from(channelsTable)
+        .where(
+          and(eq(channelsTable.id, channelId), eq(channelsTable.organisationId, organisationId))
+        )
+    );
+
+    if (!channel) {
+      throw new NonRetriableError(
+        `Could not retrieve channel - ${channelId} within organisation - ${organisationId}`
+      );
+    }
+
+    const elbaClient = createElbaClient(organisationId, region);
+
+    const object = formatDataProtectionObject({
+      teamId,
+      teamName,
+      messageId: message.id,
+      channelId,
+      channelName: channel.displayName,
+      organisationId,
+      membershipType: channel.membershipType,
+      message,
+    });
+
+    await step.run('upsert-message-to-elba', async () => {
+      await elbaClient.dataProtection.updateObjects({ objects: [object] });
+    });
+  }
+);

--- a/apps/teams/src/inngest/functions/teams/event-handlers/channel-created.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/channel-created.ts
@@ -1,66 +1,55 @@
-import { eq } from 'drizzle-orm';
-import { NonRetriableError } from 'inngest';
+import { sql } from 'drizzle-orm';
 import { db } from '@/database/client';
-import { channelsTable, organisationsTable } from '@/database/schema';
+import { channelsTable } from '@/database/schema';
 import type { TeamsEventHandler } from '@/inngest/functions/teams/event-handlers/index';
 import { decrypt } from '@/common/crypto';
 import { inngest } from '@/inngest/client';
 import { getChannel } from '@/connectors/microsoft/channels/channels';
 
-export const channelCreatedHandler: TeamsEventHandler = async ({ channelId, teamId, tenantId }) => {
-  const [organisation] = await db
-    .select({
-      id: organisationsTable.id,
-      token: organisationsTable.token,
-    })
-    .from(organisationsTable)
-    .where(eq(organisationsTable.tenantId, tenantId));
-
-  if (!organisation) {
-    throw new NonRetriableError(`Could not retrieve organisation with tenant=${tenantId}`);
-  }
-
-  const [channelInDb] = await db
-    .select({
-      id: channelsTable.id,
-    })
-    .from(channelsTable)
-    .where(eq(channelsTable.id, `${organisation.id}:${channelId}`));
-
-  if (channelInDb) {
-    return { message: 'channel already exists' };
-  }
-
-  const channel = await getChannel({
-    token: await decrypt(organisation.token),
-    teamId,
-    channelId,
-  });
-
-  if (!channel || channel.membershipType === 'private') {
-    return { message: 'Ignore private or invalid channel' };
-  }
-
-  await db
-    .insert(channelsTable)
-    .values({
-      id: `${organisation.id}:${channelId}`,
-      organisationId: organisation.id,
-      membershipType: channel.membershipType,
-      displayName: channel.displayName,
+export const channelCreatedHandler: TeamsEventHandler = async (
+  { channelId, teamId, tenantId, organisations, token, organisationId },
+  { step }
+) => {
+  const channel = await step.run('fetch-channel-from-microsoft', async () =>
+    getChannel({
+      token: await decrypt(token),
+      teamId,
       channelId,
     })
-    .onConflictDoNothing();
+  );
+
+  if (!channel || channel.membershipType === 'private') {
+    return 'Ignore private or invalid channel';
+  }
+
+  await step.run('upsert-channels-to-db', async () => {
+    await db
+      .insert(channelsTable)
+      .values(
+        organisations.map((organisation) => ({
+          id: channelId,
+          organisationId: organisation.id,
+          membershipType: channel.membershipType,
+          displayName: channel.displayName,
+        }))
+      )
+      .onConflictDoUpdate({
+        target: [channelsTable.id, channelsTable.organisationId],
+        set: {
+          displayName: sql`excluded.display_name`,
+        },
+      });
+  });
 
   await inngest.send({
     name: 'teams/channel.subscription.requested',
     data: {
-      uniqueChannelInOrganisationId: `${organisation.id}:${channel.id}`,
-      organisationId: organisation.id,
+      tenantId,
+      organisationId,
       channelId: channel.id,
       teamId,
     },
   });
 
-  return { message: 'Channel created' };
+  return 'The channel is saved in the database.';
 };

--- a/apps/teams/src/inngest/functions/teams/event-handlers/channel-deleted.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/channel-deleted.ts
@@ -1,55 +1,39 @@
 import { eq } from 'drizzle-orm';
-import { NonRetriableError } from 'inngest';
 import type { TeamsEventHandler } from '@/inngest/functions/teams/event-handlers/index';
 import { db } from '@/database/client';
-import { channelsTable, organisationsTable, subscriptionsTable } from '@/database/schema';
+import { channelsTable, subscriptionsTable } from '@/database/schema';
 import { deleteSubscription } from '@/connectors/microsoft/subscriptions/subscriptions';
 import { inngest } from '@/inngest/client';
+import { decrypt } from '@/common/crypto';
 
-export const channelDeletedHandler: TeamsEventHandler = async ({
-  channelId,
-  tenantId,
-  subscriptionId,
-}) => {
-  const [organisation] = await db
-    .select({
-      id: organisationsTable.id,
-      token: organisationsTable.token,
-      region: organisationsTable.region,
-    })
-    .from(organisationsTable)
-    .where(eq(organisationsTable.tenantId, tenantId));
+export const channelDeletedHandler: TeamsEventHandler = async (
+  { channelId, subscriptionId, organisations, token },
+  { step }
+) => {
+  await step.run('delete-subscription-in-microsoft-organisation', async () =>
+    deleteSubscription(await decrypt(token), subscriptionId)
+  );
 
-  if (!organisation) {
-    throw new NonRetriableError(`Could not retrieve organisation with tenant=${tenantId}`);
-  }
-
-  const [channel] = await db
-    .select({
-      id: channelsTable.id,
-    })
-    .from(channelsTable)
-    .where(eq(channelsTable.id, `${organisation.id}:${channelId}`));
-
-  if (!channel) {
-    throw new NonRetriableError(`Could not retrieve channel with channelId=${channelId}`);
-  }
-
-  await db.delete(subscriptionsTable).where(eq(subscriptionsTable.id, subscriptionId));
-
-  await db.delete(channelsTable).where(eq(channelsTable.id, `${organisation.id}:${channelId}`));
-
-  await deleteSubscription(organisation.token, subscriptionId);
-
-  await inngest.send({
-    name: 'teams/teams.sync.requested',
-    data: {
-      organisationId: organisation.id,
-      syncStartedAt: new Date().toISOString(),
-      skipToken: null,
-      isFirstSync: true,
-    },
+  await step.run('delete-subscription-and-channel-from-database', async () => {
+    await Promise.all([
+      db.delete(subscriptionsTable).where(eq(subscriptionsTable.id, subscriptionId)),
+      db.delete(channelsTable).where(eq(channelsTable.id, channelId)),
+    ]);
   });
 
-  return { message: 'channel was deleted' };
+  await inngest.send(
+    organisations.map((organisation) => {
+      return {
+        name: 'teams/teams.sync.requested',
+        data: {
+          organisationId: organisation.id,
+          syncStartedAt: new Date().toISOString(),
+          skipToken: null,
+          isFirstSync: true,
+        },
+      };
+    })
+  );
+
+  return 'The channel has been removed from the database';
 };

--- a/apps/teams/src/inngest/functions/teams/event-handlers/index.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/index.ts
@@ -1,3 +1,6 @@
+import type { InferSelectModel } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
+import { NonRetriableError } from 'inngest';
 import { channelCreatedHandler } from '@/inngest/functions/teams/event-handlers/channel-created';
 import type { TeamsWebhookHandlerContext } from '@/inngest/functions/teams/handle-team-webhook-event';
 import { channelDeletedHandler } from '@/inngest/functions/teams/event-handlers/channel-deleted';
@@ -7,9 +10,17 @@ import { messageCreatedOrUpdatedHandler } from '@/inngest/functions/teams/event-
 import { replyCreatedOrUpdatedHandler } from '@/inngest/functions/teams/event-handlers/reply-created-updated';
 import { messageDeletedHandler } from '@/inngest/functions/teams/event-handlers/message-deleted';
 import { replyDeletedHandler } from '@/inngest/functions/teams/event-handlers/reply-deleted';
+import { db } from '@/database/client';
+import { organisationsTable } from '@/database/schema';
+
+type TeamsEventHandlerPayload = WebhookPayload & {
+  token: string;
+  organisationId: string;
+  organisations: Pick<InferSelectModel<typeof organisationsTable>, 'id' | 'token' | 'region'>[];
+};
 
 export type TeamsEventHandler = (
-  event: WebhookPayload,
+  event: TeamsEventHandlerPayload,
   context: TeamsWebhookHandlerContext
 ) => Promise<unknown>;
 
@@ -28,5 +39,30 @@ export const teamsEventHandler = async (context: TeamsWebhookHandlerContext) => 
   const type = payload.event;
   const eventHandler = teamsEventHandlers[type];
 
-  return eventHandler(payload, context);
+  const organisations = await context.step.run('get-organisations', async () =>
+    db
+      .select({
+        id: organisationsTable.id,
+        token: organisationsTable.token,
+        region: organisationsTable.region,
+      })
+      .from(organisationsTable)
+      .where(eq(organisationsTable.tenantId, payload.tenantId))
+  );
+  const token = organisations[0]?.token;
+  const organisationId = organisations[0]?.id;
+
+  if (organisations.length === 0 || !token || !organisationId) {
+    throw new NonRetriableError('Could not retrieve any organisation with this tenantId');
+  }
+
+  return eventHandler(
+    {
+      ...payload,
+      token,
+      organisationId,
+      organisations,
+    },
+    context
+  );
 };

--- a/apps/teams/src/inngest/functions/teams/event-handlers/message-created-updated.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/message-created-updated.ts
@@ -1,81 +1,49 @@
-import { eq } from 'drizzle-orm';
-import { NonRetriableError } from 'inngest';
 import type { TeamsEventHandler } from '@/inngest/functions/teams/event-handlers/index';
-import { db } from '@/database/client';
-import { channelsTable, organisationsTable } from '@/database/schema';
 import { decrypt } from '@/common/crypto';
-import { createElbaClient } from '@/connectors/elba/client';
-import { formatDataProtectionObject } from '@/connectors/elba/data-protection/object';
 import { getMessage } from '@/connectors/microsoft/messages/messages';
 import { getTeam } from '@/connectors/microsoft/teams/teams';
 
-export const messageCreatedOrUpdatedHandler: TeamsEventHandler = async ({
-  channelId,
-  messageId,
-  teamId,
-  tenantId,
-}) => {
+export const messageCreatedOrUpdatedHandler: TeamsEventHandler = async (
+  { channelId, messageId, teamId, organisations, token },
+  { step }
+) => {
   if (!messageId) {
     return;
   }
 
-  const [organisation] = await db
-    .select({
-      id: organisationsTable.id,
-      token: organisationsTable.token,
-      region: organisationsTable.region,
-    })
-    .from(organisationsTable)
-    .where(eq(organisationsTable.tenantId, tenantId));
+  const decryptedToken = await decrypt(token);
 
-  if (!organisation) {
-    throw new NonRetriableError(`Could not retrieve organisation with tenant=${tenantId}`);
-  }
-
-  const [channel] = await db
-    .select({
-      id: channelsTable.id,
-      displayName: channelsTable.displayName,
-      membershipType: channelsTable.membershipType,
-    })
-    .from(channelsTable)
-    .where(eq(channelsTable.id, `${organisation.id}:${channelId}`));
-
-  if (!channel) {
-    throw new NonRetriableError(
-      `Could not retrieve channel with id=${organisation.id}:${channelId}`
-    );
-  }
-
-  const team = await getTeam(organisation.token, teamId);
+  const team = await getTeam(decryptedToken, teamId);
 
   if (!team) {
-    return;
+    return 'Could not find a team';
   }
 
-  const message = await getMessage({
-    token: await decrypt(organisation.token),
-    teamId,
-    channelId,
-    messageId,
-  });
+  const message = await step.run('fetch-message-from-microsoft', async () =>
+    getMessage({
+      token: decryptedToken,
+      teamId,
+      channelId,
+      messageId,
+    })
+  );
 
   if (!message || message.messageType !== 'message') {
-    return;
+    return 'Ignoring invalid message';
   }
 
-  const elbaClient = createElbaClient(organisation.id, organisation.region);
-
-  const object = formatDataProtectionObject({
-    teamId,
-    teamName: team.displayName,
-    messageId: message.id,
-    channelId,
-    channelName: channel.displayName,
-    organisationId: organisation.id,
-    membershipType: channel.membershipType,
-    message,
-  });
-
-  await elbaClient.dataProtection.updateObjects({ objects: [object] });
+  await step.sendEvent(
+    'request-to-upsert-message',
+    organisations.map(({ id, region }) => ({
+      name: 'teams/data.protection.object.upsert.requested',
+      data: {
+        organisationId: id,
+        region,
+        teamId,
+        teamName: team.displayName,
+        channelId,
+        message,
+      },
+    }))
+  );
 };

--- a/apps/teams/src/inngest/functions/teams/event-handlers/message-deleted.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/message-deleted.ts
@@ -1,29 +1,22 @@
-import { eq } from 'drizzle-orm';
-import { NonRetriableError } from 'inngest';
 import type { TeamsEventHandler } from '@/inngest/functions/teams/event-handlers/index';
-import { db } from '@/database/client';
-import { organisationsTable } from '@/database/schema';
-import { createElbaClient } from '@/connectors/elba/client';
 
-export const messageDeletedHandler: TeamsEventHandler = async ({ messageId, tenantId }) => {
+export const messageDeletedHandler: TeamsEventHandler = async (
+  { messageId, organisations },
+  { step }
+) => {
   if (!messageId) {
     return;
   }
 
-  const [organisation] = await db
-    .select({
-      id: organisationsTable.id,
-      token: organisationsTable.token,
-      region: organisationsTable.region,
-    })
-    .from(organisationsTable)
-    .where(eq(organisationsTable.tenantId, tenantId));
-
-  if (!organisation) {
-    throw new NonRetriableError(`Could not retrieve organisation with tenant=${tenantId}`);
-  }
-
-  const elbaClient = createElbaClient(organisation.id, organisation.region);
-
-  await elbaClient.dataProtection.deleteObjects({ ids: [`${organisation.id}:${messageId}`] });
+  await step.sendEvent(
+    'request-message-delete',
+    organisations.map(({ id, region }) => ({
+      name: 'teams/data.protection.object.delete.requested',
+      data: {
+        organisationId: id,
+        region,
+        messageId,
+      },
+    }))
+  );
 };

--- a/apps/teams/src/inngest/functions/teams/event-handlers/reply-created-updated.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/reply-created-updated.ts
@@ -1,84 +1,50 @@
-import { eq } from 'drizzle-orm';
-import { NonRetriableError } from 'inngest';
 import type { TeamsEventHandler } from '@/inngest/functions/teams/event-handlers/index';
-import { db } from '@/database/client';
-import { channelsTable, organisationsTable } from '@/database/schema';
 import { decrypt } from '@/common/crypto';
-import { createElbaClient } from '@/connectors/elba/client';
-import { formatDataProtectionObject } from '@/connectors/elba/data-protection/object';
 import { getReply } from '@/connectors/microsoft/replies/replies';
 import { getTeam } from '@/connectors/microsoft/teams/teams';
 
-export const replyCreatedOrUpdatedHandler: TeamsEventHandler = async ({
-  channelId,
-  replyId,
-  teamId,
-  messageId,
-  tenantId,
-}) => {
+export const replyCreatedOrUpdatedHandler: TeamsEventHandler = async (
+  { channelId, replyId, teamId, messageId, organisations, token },
+  { step }
+) => {
   if (!messageId || !replyId) {
     return;
   }
 
-  const [organisation] = await db
-    .select({
-      id: organisationsTable.id,
-      token: organisationsTable.token,
-      region: organisationsTable.region,
-    })
-    .from(organisationsTable)
-    .where(eq(organisationsTable.tenantId, tenantId));
+  const decryptedToken = await decrypt(token);
 
-  if (!organisation) {
-    throw new NonRetriableError(`Could not retrieve organisation with tenant=${tenantId}`);
-  }
-
-  const [channel] = await db
-    .select({
-      id: channelsTable.id,
-      displayName: channelsTable.displayName,
-      membershipType: channelsTable.membershipType,
-    })
-    .from(channelsTable)
-    .where(eq(channelsTable.id, `${organisation.id}:${channelId}`));
-
-  if (!channel) {
-    throw new NonRetriableError(
-      `Could not retrieve channel with channelId=${organisation.id}:${channelId}`
-    );
-  }
-
-  const team = await getTeam(organisation.token, teamId);
+  const team = await getTeam(decryptedToken, teamId);
 
   if (!team) {
-    return;
+    return 'Could not find a team';
   }
 
-  const reply = await getReply({
-    token: await decrypt(organisation.token),
-    teamId,
-    channelId,
-    messageId,
-    replyId,
-  });
+  const reply = await step.run('fetch-reply-from-microsoft', async () =>
+    getReply({
+      token: decryptedToken,
+      teamId,
+      channelId,
+      messageId,
+      replyId,
+    })
+  );
 
   if (!reply || reply.messageType !== 'message') {
-    return;
+    return 'Ignoring invalid reply';
   }
 
-  const elbaClient = createElbaClient(organisation.id, organisation.region);
-
-  const object = formatDataProtectionObject({
-    teamId,
-    teamName: team.displayName,
-    channelId,
-    messageId,
-    replyId: reply.id,
-    channelName: channel.displayName,
-    organisationId: organisation.id,
-    membershipType: channel.membershipType,
-    message: reply,
-  });
-
-  await elbaClient.dataProtection.updateObjects({ objects: [object] });
+  await step.sendEvent(
+    'request-to-upsert-reply',
+    organisations.map(({ id, region }) => ({
+      name: 'teams/data.protection.object.upsert.requested',
+      data: {
+        organisationId: id,
+        region,
+        teamId,
+        teamName: team.displayName,
+        channelId,
+        message: reply,
+      },
+    }))
+  );
 };

--- a/apps/teams/src/inngest/functions/teams/event-handlers/reply-deleted.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/reply-deleted.ts
@@ -1,29 +1,22 @@
-import { NonRetriableError } from 'inngest';
-import { eq } from 'drizzle-orm';
 import type { TeamsEventHandler } from '@/inngest/functions/teams/event-handlers/index';
-import { db } from '@/database/client';
-import { organisationsTable } from '@/database/schema';
-import { createElbaClient } from '@/connectors/elba/client';
 
-export const replyDeletedHandler: TeamsEventHandler = async ({ replyId, messageId, tenantId }) => {
+export const replyDeletedHandler: TeamsEventHandler = async (
+  { replyId, messageId, organisations },
+  { step }
+) => {
   if (!messageId || !replyId) {
     return;
   }
 
-  const [organisation] = await db
-    .select({
-      id: organisationsTable.id,
-      token: organisationsTable.token,
-      region: organisationsTable.region,
-    })
-    .from(organisationsTable)
-    .where(eq(organisationsTable.tenantId, tenantId));
-
-  if (!organisation) {
-    throw new NonRetriableError(`Could not retrieve organisation with tenant=${tenantId}`);
-  }
-
-  const elbaClient = createElbaClient(organisation.id, organisation.region);
-
-  await elbaClient.dataProtection.deleteObjects({ ids: [`${organisation.id}:${replyId}`] });
+  await step.sendEvent(
+    'request-reply-delete',
+    organisations.map(({ id, region }) => ({
+      name: 'teams/data.protection.object.delete.requested',
+      data: {
+        organisationId: id,
+        region,
+        messageId,
+      },
+    }))
+  );
 };

--- a/apps/teams/src/inngest/functions/teams/index.ts
+++ b/apps/teams/src/inngest/functions/teams/index.ts
@@ -1,3 +1,5 @@
 import { handleTeamsWebhookEvent } from '@/inngest/functions/teams/handle-team-webhook-event';
+import { messageDelete } from '@/inngest/functions/teams/data-protection/message-delete';
+import { messageUpsert } from '@/inngest/functions/teams/data-protection/message-upsert';
 
-export const teamsFunctions = [handleTeamsWebhookEvent];
+export const teamsFunctions = [handleTeamsWebhookEvent, messageDelete, messageUpsert];


### PR DESCRIPTION
## Description
As we can have multiple organisations within same tenant (Microsoft Org) and therefor we need to handle it. The main problem is that MS have restrictions regarding how many subscriptions could be created for same resources in same tenant. 
So we should not create subscriptions for same resources in same tenant for different orgs and reuse one subscription for all orgs.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
