### PR TITLE
chore(slack): set data protection sync schedule frequency from environment variable

### DIFF
--- a/apps/slack/.env.test
+++ b/apps/slack/.env.test
@@ -1,3 +1,4 @@
+DATA_PROTECTION_SYNC_CRON='0 0 1 * *'
 ELBA_API_BASE_URL=http://localhost:8080
 ELBA_API_KEY=elba-api-key
 ELBA_REDIRECT_URL=http://elba

--- a/apps/slack/src/common/env.ts
+++ b/apps/slack/src/common/env.ts
@@ -17,6 +17,7 @@ export const env = createEnv({
     ENCRYPTION_KEY: z.string().length(64),
     DATABASE_PROXY_PORT: z.coerce.number().int().positive().optional(),
     DATABASE_URL: z.string().min(1),
+    DATA_PROTECTION_SYNC_CRON: z.string().min(1),
     SLACK_APP_LEVEL_TOKEN: z.string().min(1),
     SLACK_CLIENT_ID: z.string().min(1),
     SLACK_CLIENT_SECRET: z.string().min(1),

--- a/apps/slack/src/inngest/functions/data-protection/schedule-data-protection-sync.ts
+++ b/apps/slack/src/inngest/functions/data-protection/schedule-data-protection-sync.ts
@@ -1,9 +1,10 @@
+import { env } from '@/common/env';
 import { db } from '@/database/client';
 import { inngest } from '@/inngest/client';
 
 export const scheduleDataProtectionSync = inngest.createFunction(
   { id: 'slack-schedule-data-protection-sync', retries: 5 },
-  { cron: 'TZ=Europe/Paris 0 0 * * 0' }, // every sunday at midnight
+  { cron: env.DATA_PROTECTION_SYNC_CRON },
   async ({ step }) => {
     const teams = await step.run('get-teams', async () => {
       return db.query.teamsTable.findMany({


### PR DESCRIPTION
## Description

Slack data protection sync frequency was hardcoded and is now set using environment variable

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
