### PR TITLE
chore(slack): add logs for handled webhook events and extend sync timeout

### DIFF
--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.test.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.test.ts
@@ -161,7 +161,7 @@ describe('synchronize-conversation-messages', () => {
     expect(step.waitForEvent).toBeCalledWith('wait-for-thread-message-sync-complete-thread-id', {
       event: 'slack/conversations.sync.thread.messages.completed',
       if: "async.data.teamId == 'team-id' && async.data.conversationId == 'conversation-id' && async.data.threadId == 'thread-id'",
-      timeout: '1d',
+      timeout: '30 days',
     });
 
     expect(step.sendEvent).toBeCalledTimes(2);
@@ -322,7 +322,7 @@ describe('synchronize-conversation-messages', () => {
     expect(step.waitForEvent).toBeCalledWith('wait-for-thread-message-sync-complete-thread-id', {
       event: 'slack/conversations.sync.thread.messages.completed',
       if: "async.data.teamId == 'team-id' && async.data.conversationId == 'conversation-id' && async.data.threadId == 'thread-id'",
-      timeout: '1d',
+      timeout: '30 days',
     });
 
     expect(step.sendEvent).toBeCalledTimes(2);

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
@@ -147,7 +147,7 @@ export const synchronizeConversationMessages = inngest.createFunction(
       const eventsToWait = threadIds.map(async (threadId) => {
         return step.waitForEvent(`wait-for-thread-message-sync-complete-${threadId}`, {
           event: 'slack/conversations.sync.thread.messages.completed',
-          timeout: '1d',
+          timeout: '30 days',
           if: `async.data.teamId == '${teamId}' && async.data.conversationId == '${conversationId}' && async.data.threadId == '${threadId}'`,
         });
       });

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversations.test.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversations.test.ts
@@ -140,12 +140,12 @@ describe('synchronize-conversations', () => {
     expect(step.waitForEvent).toBeCalledWith('wait-for-message-complete-channel-id-1', {
       event: 'slack/conversations.sync.messages.completed',
       if: "async.data.teamId == 'team-id' && async.data.conversationId == 'channel-id-1'",
-      timeout: '1 day',
+      timeout: '30 days',
     });
     expect(step.waitForEvent).toBeCalledWith('wait-for-message-complete-channel-id-2', {
       event: 'slack/conversations.sync.messages.completed',
       if: "async.data.teamId == 'team-id' && async.data.conversationId == 'channel-id-2'",
-      timeout: '1 day',
+      timeout: '30 days',
     });
 
     expect(step.sendEvent).toBeCalledTimes(2);
@@ -328,12 +328,12 @@ describe('synchronize-conversations', () => {
     expect(step.waitForEvent).toBeCalledWith('wait-for-message-complete-channel-id-1', {
       event: 'slack/conversations.sync.messages.completed',
       if: "async.data.teamId == 'team-id' && async.data.conversationId == 'channel-id-1'",
-      timeout: '1 day',
+      timeout: '30 days',
     });
     expect(step.waitForEvent).toBeCalledWith('wait-for-message-complete-channel-id-2', {
       event: 'slack/conversations.sync.messages.completed',
       if: "async.data.teamId == 'team-id' && async.data.conversationId == 'channel-id-2'",
-      timeout: '1 day',
+      timeout: '30 days',
     });
 
     expect(step.sendEvent).toBeCalledTimes(1);

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
@@ -101,7 +101,7 @@ export const synchronizeConversations = inngest.createFunction(
       const eventsToWait = conversationsToInsert.map(({ id: conversationId }) =>
         step.waitForEvent(`wait-for-message-complete-${conversationId}`, {
           event: 'slack/conversations.sync.messages.completed',
-          timeout: '1 day',
+          timeout: '30 days',
           if: `async.data.teamId == '${teamId}' && async.data.conversationId == '${conversationId}'`,
         })
       );

--- a/apps/slack/src/inngest/functions/slack/event-handlers/index.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/index.ts
@@ -37,5 +37,7 @@ export const slackEventHandler = async (context: SlackWebhookHandlerContext) => 
     return { message: 'Ignored: unhandled slack event type', type };
   }
 
+  context.logger.info('Handling Slack event', { type, teamId: payload.team_id });
+
   return eventHandler(payload as never, context);
 };


### PR DESCRIPTION
## Description

This adds logs for Slack handled webhook events extends and extends the Slack sync timeout 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
