### PR TITLE
fix(Google): fix shared drive files permissions deletion

### DIFF
--- a/apps/google/src/connectors/google/permissions.ts
+++ b/apps/google/src/connectors/google/permissions.ts
@@ -34,10 +34,14 @@ const googleFilePermissionFields = [
 
 const googleSharedDriveManagerPermissionFields = ['emailAddress', 'id', 'role', 'type'];
 
-export const deleteGooglePermission = async (
-  deletePermissionParams: drive.Params$Resource$Permissions$Delete
-) => {
-  return new drive.Drive({}).permissions.delete(deletePermissionParams);
+export const deleteGooglePermission = async ({
+  supportsAllDrives = true,
+  ...deletePermissionParams
+}: drive.Params$Resource$Permissions$Delete) => {
+  return new drive.Drive({}).permissions.delete({
+    ...deletePermissionParams,
+    supportsAllDrives,
+  });
 };
 
 const listPermissions = async <T>(

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
@@ -71,7 +71,7 @@ describe('sync-data-protection-drive', () => {
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       pageSize: 250,
       pageToken: undefined,
-      q: '"admin@org.local" in owners and mimeType != \'application/vnd.google-apps.folder\'',
+      q: '"user-id-1" in owners and mimeType != \'application/vnd.google-apps.folder\'',
     });
 
     expect(step.run).toBeCalledWith('list-files-permissions', expect.any(Function));

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.ts
@@ -81,7 +81,7 @@ export const syncDataProtectionDrive = inngest.createFunction(
               corpora: 'drive',
             }
           : {
-              q: `"${managerEmail}" in owners and mimeType != 'application/vnd.google-apps.folder'`,
+              q: `"${managerUserId}" in owners and mimeType != 'application/vnd.google-apps.folder'`,
             }),
       });
     });

--- a/apps/google/src/inngest/functions/data-protection/sync-shared-drives.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-shared-drives.test.ts
@@ -140,21 +140,18 @@ describe('sync-data-protection-shared-drives', () => {
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       fileId: 'shared-drive-id-1',
       pageSize: 100,
-      useDomainAdminAccess: true,
     });
     expect(googlePermissions.listAllGoogleSharedDriveManagerPermissions).toBeCalledWith({
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- this is a mock
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       fileId: 'shared-drive-id-2',
       pageSize: 100,
-      useDomainAdminAccess: true,
     });
     expect(googlePermissions.listAllGoogleSharedDriveManagerPermissions).toBeCalledWith({
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- this is a mock
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       fileId: 'shared-drive-id-3',
       pageSize: 100,
-      useDomainAdminAccess: true,
     });
 
     expect(googleMembers.listAllGoogleMembers).toBeCalledTimes(1);
@@ -363,21 +360,18 @@ describe('sync-data-protection-shared-drives', () => {
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       fileId: 'shared-drive-id-1',
       pageSize: 100,
-      useDomainAdminAccess: true,
     });
     expect(googlePermissions.listAllGoogleSharedDriveManagerPermissions).toBeCalledWith({
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- this is a mock
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       fileId: 'shared-drive-id-2',
       pageSize: 100,
-      useDomainAdminAccess: true,
     });
     expect(googlePermissions.listAllGoogleSharedDriveManagerPermissions).toBeCalledWith({
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- this is a mock
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       fileId: 'shared-drive-id-3',
       pageSize: 100,
-      useDomainAdminAccess: true,
     });
 
     expect(googleMembers.listAllGoogleMembers).toBeCalledTimes(1);

--- a/apps/google/src/inngest/functions/data-protection/sync-shared-drives.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-shared-drives.ts
@@ -67,7 +67,6 @@ export const syncDataProtectionSharedDrives = inngest.createFunction(
           const managerPermissions = await listAllGoogleSharedDriveManagerPermissions({
             auth: authClient,
             fileId: sharedDriveId,
-            useDomainAdminAccess: true,
             pageSize: 100, // Set pageSize to max value
           });
 


### PR DESCRIPTION
## Description

This fixes a bug where permissions deletion would be ignored for files on shared drives.

The parameter `supportsAllDrives` was not set during the api call to delete permission. As a consequence, the response was 404 `notFound` which we just ignored assuming the permission was already deleted while it was not.

This also updates the logic to list list files on personal drives to make sure the file is owned by the owner of the personal drive. Instead of relying on email, which could change and might not be reliable, we are now using the user id instead.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
