### PR TITLE
feat(datadog): add url param, modify user deletion to suspension

### DIFF
--- a/apps/datadog/src/connectors/datadog/regions.ts
+++ b/apps/datadog/src/connectors/datadog/regions.ts
@@ -41,7 +41,7 @@ export const getDatadogRegionAPIBaseURL = (region: string) => {
 export const getDatadogRegionURL = (region: string) => {
   const regionDomain = DATADOG_REGIONS_URLS[region as DatadogRegion];
   if (!regionDomain) {
-    throw new Error('Invalid Datadog region');
+    throw new Error('Invalid Datadog URL');
   }
 
   return `https://${regionDomain}`;

--- a/apps/datadog/src/connectors/datadog/regions.ts
+++ b/apps/datadog/src/connectors/datadog/regions.ts
@@ -12,7 +12,14 @@ export const DATADOG_REGIONS_DOMAINS: Record<DatadogRegion, string> = {
   US5: 'us5.datadoghq.com',
   'US1-FED': 'ddog-gov.com',
 };
-
+export const DATADOG_REGIONS_URLS: Record<DatadogRegion, string> = {
+  AP1: 'ap1.datadoghq.com',
+  EU1: 'app.datadoghq.eu',
+  US1: 'app.datadoghq.com',
+  US3: 'us3.datadoghq.com',
+  US5: 'us5.datadoghq.com',
+  'US1-FED': 'ddog-gov.com',
+};
 export const DATADOG_REGIONS_NAMES: Record<DatadogRegion, string> = {
   AP1: 'Japan',
   EU1: 'Europe - Germany',
@@ -29,4 +36,13 @@ export const getDatadogRegionAPIBaseURL = (region: string) => {
   }
 
   return `https://api.${regionDomain}`;
+};
+
+export const getDatadogRegionURL = (region: string) => {
+  const regionDomain = DATADOG_REGIONS_URLS[region as DatadogRegion];
+  if (!regionDomain) {
+    throw new Error('Invalid Datadog region');
+  }
+
+  return `https://${regionDomain}`;
 };

--- a/apps/datadog/src/connectors/datadog/users.test.ts
+++ b/apps/datadog/src/connectors/datadog/users.test.ts
@@ -105,7 +105,7 @@ describe('users connector', () => {
   describe('deleteUser', () => {
     beforeEach(() => {
       server.use(
-        http.delete<{ testId: string }>(
+        http.patch<{ testId: string }>(
           `https://api.datadoghq.eu/api/v2/users/:userId`,
           ({ request }) => {
             const url = new URL(request.url.toString());

--- a/apps/datadog/src/connectors/datadog/users.ts
+++ b/apps/datadog/src/connectors/datadog/users.ts
@@ -87,11 +87,20 @@ export const deleteUser = async ({ apiKey, appKey, sourceRegion, userId }: Delet
   const url = new URL(`${getDatadogRegionAPIBaseURL(sourceRegion)}/api/v2/users/${userId}`);
 
   const response = await fetch(url.toString(), {
-    method: 'DELETE',
+    method: 'PATCH',
     headers: {
       'DD-API-KEY': apiKey,
       'DD-APPLICATION-KEY': appKey,
     },
+    body: JSON.stringify({
+      data: {
+        attributes: {
+          disabled: true,
+        },
+        id: userId,
+        type: 'users',
+      },
+    }),
   });
 
   if (!response.ok && response.status !== 404) {

--- a/apps/datadog/src/inngest/functions/users/sync-users.test.ts
+++ b/apps/datadog/src/inngest/functions/users/sync-users.test.ts
@@ -9,7 +9,7 @@ import { syncUsers } from './sync-users';
 
 const apiKey = 'test-access-token';
 const appKey = 'test-appKey';
-const sourceRegion = 'EU';
+const sourceRegion = 'EU1';
 
 const organisation = {
   id: '00000000-0000-0000-0000-000000000001',
@@ -97,6 +97,7 @@ describe('synchronize-users', () => {
           id: 'id-0',
           authMethod: 'password',
           isSuspendable: true,
+          url: 'https://app.datadoghq.eu/organization-settings/users?user_id=id-0',
         },
         {
           additionalEmails: [],
@@ -105,6 +106,7 @@ describe('synchronize-users', () => {
           id: 'id-1',
           authMethod: 'password',
           isSuspendable: true,
+          url: 'https://app.datadoghq.eu/organization-settings/users?user_id=id-1',
         },
       ],
     });
@@ -139,6 +141,7 @@ describe('synchronize-users', () => {
           id: 'id-0',
           authMethod: 'password',
           isSuspendable: true,
+          url: 'https://app.datadoghq.eu/organization-settings/users?user_id=id-0',
         },
         {
           additionalEmails: [],
@@ -147,6 +150,7 @@ describe('synchronize-users', () => {
           id: 'id-1',
           authMethod: 'password',
           isSuspendable: true,
+          url: 'https://app.datadoghq.eu/organization-settings/users?user_id=id-1',
         },
       ],
     });


### PR DESCRIPTION
## Description

Datadog Integration
1. Added `url` params, not `isSuspendable` because I couldn't filter owner and its id.
2. Modified user deletion to suspension.

## Additional Notes

N/A

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
