### PR TITLE
fix(slack): sync improvements

### DIFF
--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.test.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.test.ts
@@ -37,7 +37,7 @@ describe('synchronize-conversation-messages', () => {
           ts: '1700000001.000000',
           user: 'user',
           text: 'text1',
-          thread_ts: 'thread-id',
+          thread_ts: '1700000001.000000',
         },
         {
           type: 'message',
@@ -90,7 +90,7 @@ describe('synchronize-conversation-messages', () => {
     await expect(result).resolves.toStrictEqual({
       objects: 2,
       nextCursor: 'next-cursor',
-      threadIds: ['thread-id'],
+      threadIds: ['1700000001.000000'],
     });
 
     expect(crypto.decrypt).toBeCalledTimes(1);
@@ -158,11 +158,14 @@ describe('synchronize-conversation-messages', () => {
     });
 
     expect(step.waitForEvent).toBeCalledTimes(1);
-    expect(step.waitForEvent).toBeCalledWith('wait-for-thread-message-sync-complete-thread-id', {
-      event: 'slack/conversations.sync.thread.messages.completed',
-      if: "async.data.teamId == 'team-id' && async.data.conversationId == 'conversation-id' && async.data.threadId == 'thread-id'",
-      timeout: '30 days',
-    });
+    expect(step.waitForEvent).toBeCalledWith(
+      'wait-for-thread-message-sync-complete-1700000001.000000',
+      {
+        event: 'slack/conversations.sync.thread.messages.completed',
+        if: "async.data.teamId == 'team-id' && async.data.conversationId == 'conversation-id' && async.data.threadId == '1700000001.000000'",
+        timeout: '30 days',
+      }
+    );
 
     expect(step.sendEvent).toBeCalledTimes(2);
     expect(step.sendEvent).toBeCalledWith('start-conversation-thread-messages-synchronization', [
@@ -171,7 +174,7 @@ describe('synchronize-conversation-messages', () => {
           conversationId: 'conversation-id',
           isFirstSync: true,
           teamId: 'team-id',
-          threadId: 'thread-id',
+          threadId: '1700000001.000000',
         },
         name: 'slack/conversations.sync.thread.messages.requested',
       },
@@ -199,7 +202,7 @@ describe('synchronize-conversation-messages', () => {
           ts: '1700000001.000000',
           user: 'user',
           text: 'text1',
-          thread_ts: 'thread-id',
+          thread_ts: '1700000001.000000',
         },
         {
           type: 'message',
@@ -250,7 +253,7 @@ describe('synchronize-conversation-messages', () => {
     await expect(result).resolves.toStrictEqual({
       objects: 2,
       nextCursor: undefined,
-      threadIds: ['thread-id'],
+      threadIds: ['1700000001.000000'],
     });
 
     expect(crypto.decrypt).toBeCalledTimes(1);
@@ -319,11 +322,14 @@ describe('synchronize-conversation-messages', () => {
     });
 
     expect(step.waitForEvent).toBeCalledTimes(1);
-    expect(step.waitForEvent).toBeCalledWith('wait-for-thread-message-sync-complete-thread-id', {
-      event: 'slack/conversations.sync.thread.messages.completed',
-      if: "async.data.teamId == 'team-id' && async.data.conversationId == 'conversation-id' && async.data.threadId == 'thread-id'",
-      timeout: '30 days',
-    });
+    expect(step.waitForEvent).toBeCalledWith(
+      'wait-for-thread-message-sync-complete-1700000001.000000',
+      {
+        event: 'slack/conversations.sync.thread.messages.completed',
+        if: "async.data.teamId == 'team-id' && async.data.conversationId == 'conversation-id' && async.data.threadId == '1700000001.000000'",
+        timeout: '30 days',
+      }
+    );
 
     expect(step.sendEvent).toBeCalledTimes(2);
     expect(step.sendEvent).toBeCalledWith('start-conversation-thread-messages-synchronization', [
@@ -332,7 +338,7 @@ describe('synchronize-conversation-messages', () => {
           conversationId: 'conversation-id',
           isFirstSync: false,
           teamId: 'team-id',
-          threadId: 'thread-id',
+          threadId: '1700000001.000000',
         },
         name: 'slack/conversations.sync.thread.messages.requested',
       },

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
@@ -106,12 +106,17 @@ export const synchronizeConversationMessages = inngest.createFunction(
         const dpObjects: DataProtectionObject[] = [];
         const threads: string[] = [];
         for (const message of messages) {
-          if (message.thread_ts) {
+          if (message.thread_ts && message.thread_ts === message.ts) {
             threads.push(message.thread_ts);
           }
 
           const result = slackMessageSchema.safeParse(message);
-          if (message.type !== 'message' || message.team !== teamId || !result.success) {
+          if (
+            message.type !== 'message' ||
+            message.team !== teamId ||
+            message.bot_id ||
+            !result.success
+          ) {
             continue;
           }
 

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
@@ -58,14 +58,6 @@ export const synchronizeConversationMessages = inngest.createFunction(
     },
     step,
   }) => {
-    if (!isFirstSync) {
-      await step.sendEvent('ignored', {
-        name: 'slack/conversations.sync.messages.completed',
-        data: { teamId, conversationId },
-      });
-      return { status: 'ignored' };
-    }
-
     const conversation = await step.run('get-conversation', async () => {
       const result = await db.query.conversationsTable.findFirst({
         where: and(

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.ts
@@ -58,6 +58,14 @@ export const synchronizeConversationMessages = inngest.createFunction(
     },
     step,
   }) => {
+    if (!isFirstSync) {
+      await step.sendEvent('ignored', {
+        name: 'slack/conversations.sync.messages.completed',
+        data: { teamId, conversationId },
+      });
+      return { status: 'ignored' };
+    }
+
     const conversation = await step.run('get-conversation', async () => {
       const result = await db.query.conversationsTable.findFirst({
         where: and(

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
@@ -109,7 +109,12 @@ export const synchronizeConversationThreadMessages = inngest.createFunction(
       for (const message of messages) {
         const result = slackMessageSchema.safeParse(message);
 
-        if (message.type !== 'message' || message.team !== teamId || !result.success) {
+        if (
+          message.type !== 'message' ||
+          message.team !== teamId ||
+          message.bot_id ||
+          !result.success
+        ) {
           continue;
         }
 

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
@@ -62,14 +62,6 @@ export const synchronizeConversationThreadMessages = inngest.createFunction(
     },
     step,
   }) => {
-    if (!isFirstSync) {
-      await step.sendEvent('ignored', {
-        name: 'slack/conversations.sync.thread.messages.completed',
-        data: { teamId, conversationId, threadId },
-      });
-      return { status: 'ignored' };
-    }
-
     const conversation = await step.run('get-conversation', async () => {
       return db.query.conversationsTable.findFirst({
         where: and(

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.ts
@@ -62,6 +62,14 @@ export const synchronizeConversationThreadMessages = inngest.createFunction(
     },
     step,
   }) => {
+    if (!isFirstSync) {
+      await step.sendEvent('ignored', {
+        name: 'slack/conversations.sync.thread.messages.completed',
+        data: { teamId, conversationId, threadId },
+      });
+      return { status: 'ignored' };
+    }
+
     const conversation = await step.run('get-conversation', async () => {
       return db.query.conversationsTable.findFirst({
         where: and(

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
@@ -35,6 +35,10 @@ export const synchronizeConversations = inngest.createFunction(
     },
     step,
   }) => {
+    if (!isFirstSync) {
+      return { status: 'ignored' };
+    }
+
     const { token, elbaOrganisationId, elbaRegion } = await step.run('get-team', async () => {
       const result = await db.query.teamsTable.findFirst({
         where: eq(teamsTable.id, teamId),

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversations.ts
@@ -35,10 +35,6 @@ export const synchronizeConversations = inngest.createFunction(
     },
     step,
   }) => {
-    if (!isFirstSync) {
-      return { status: 'ignored' };
-    }
-
     const { token, elbaOrganisationId, elbaRegion } = await step.run('get-team', async () => {
       const result = await db.query.teamsTable.findFirst({
         where: eq(teamsTable.id, teamId),

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-archive.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-archive.test.ts
@@ -14,7 +14,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_archive';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
   });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-created.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-created.test.ts
@@ -14,7 +14,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_created';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
   });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-deleted.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-deleted.test.ts
@@ -14,7 +14,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_deleted';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
   });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-rename.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-rename.test.ts
@@ -14,7 +14,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_rename';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
   });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-shared.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-shared.test.ts
@@ -16,7 +16,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_shared';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.mock('slack-web-api-client');
     vi.mock('@/common/crypto');

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-unarchive.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-unarchive.test.ts
@@ -16,7 +16,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_unarchive';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
     vi.mock('slack-web-api-client');

--- a/apps/slack/src/inngest/functions/slack/event-handlers/channel-unshared.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/channel-unshared.test.ts
@@ -14,7 +14,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'channel_unshared';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
   });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/index.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/index.ts
@@ -1,31 +1,31 @@
 import type { SlackWebhookHandlerContext, SlackEventHandlers } from './types';
 import { appRateLimitedHandler } from './app-rate-limited';
 import { appUninstalledHandler } from './app-uninstalled';
-import { channelArchiveHandler } from './channel-archive';
-import { channelCreatedHandler } from './channel-created';
-import { channelDeletedHandler } from './channel-deleted';
+// import { channelArchiveHandler } from './channel-archive';
+// import { channelCreatedHandler } from './channel-created';
+// import { channelDeletedHandler } from './channel-deleted';
 // import { channelIdChangedHandler } from './channel-id-changed';
-import { channelRenameHandler } from './channel-rename';
-import { channelUnarchiveHandler } from './channel-unarchive';
+// import { channelRenameHandler } from './channel-rename';
+// import { channelUnarchiveHandler } from './channel-unarchive';
 import { messageHandler } from './message';
-import { teamDomainChangedHandler } from './team-domain-changed';
+// import { teamDomainChangedHandler } from './team-domain-changed';
 import { userChangeHandler } from './user-change';
-import { channelUnsharedHandler } from './channel-unshared';
-import { channelSharedHandler } from './channel-shared';
+// import { channelUnsharedHandler } from './channel-unshared';
+// import { channelSharedHandler } from './channel-shared';
 
 const slackEventHandlers: SlackEventHandlers = {
   app_rate_limited: appRateLimitedHandler,
   app_uninstalled: appUninstalledHandler,
-  channel_archive: channelArchiveHandler,
-  channel_created: channelCreatedHandler,
-  channel_deleted: channelDeletedHandler,
+  // channel_archive: channelArchiveHandler,
+  // channel_created: channelCreatedHandler,
+  // channel_deleted: channelDeletedHandler,
   // channel_id_changed: channelIdChangedHandler, // For private channel only
-  channel_rename: channelRenameHandler,
-  channel_shared: channelSharedHandler,
-  channel_unarchive: channelUnarchiveHandler,
-  channel_unshared: channelUnsharedHandler,
+  // channel_rename: channelRenameHandler,
+  // channel_shared: channelSharedHandler,
+  // channel_unarchive: channelUnarchiveHandler,
+  // channel_unshared: channelUnsharedHandler,
   message: messageHandler,
-  team_domain_changed: teamDomainChangedHandler,
+  // team_domain_changed: teamDomainChangedHandler,
   user_change: userChangeHandler,
 };
 

--- a/apps/slack/src/inngest/functions/slack/event-handlers/team-domain-changed.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/team-domain-changed.test.ts
@@ -14,7 +14,7 @@ const mockedDate = '2023-01-01T00:00:00.000Z';
 
 const eventType: SlackEvent['type'] = 'team_domain_changed';
 
-describe(`handle-slack-webhook-event ${eventType}`, () => {
+describe.skip(`handle-slack-webhook-event ${eventType}`, () => {
   beforeAll(() => {
     vi.setSystemTime(mockedDate);
   });


### PR DESCRIPTION
## Description

This contains a few changes to attempt improving Slack syncs:
- Fix a bug where we attempted to sync thread from thread replies instead of root message
- Ignore sending bot messages to elba
- Ignore all webhook events needing a new state of the world sync to avoid stacking multiple sync at the same time.
- Apply Inngest recommendation: await sendEvent & waitForEvent at the same time, the waitForEvent should be detected and triggered in priority before the sendEvent to avoid race

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 486e025be935319bc66aa361a59ffcc3a635d5d3  | 
|--------|--------|

### Summary:
Optimize Slack sync by skipping non-first syncs and filtering bot messages, and comment out unused event handlers.

**Key points**:
- Add `isFirstSync` check in `synchronizeConversationMessages`, `synchronizeConversationThreadMessages`, and `synchronizeConversations` to skip non-first syncs.
- Filter out bot messages in `synchronizeConversationMessages` and `synchronizeConversationThreadMessages`.
- Comment out unused event handlers in `apps/slack/src/inngest/functions/slack/event-handlers/index.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->