### PR TITLE
fix(Google): fix a bug during personal drive

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_FORCE: ${{ github.run_attempt > 1 && 'true' || 'false' }}
 
     steps:
       - name: Checkout

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
@@ -71,7 +71,7 @@ describe('sync-data-protection-drive', () => {
       auth: serviceAccountClientSpy.mock.results[0]?.value,
       pageSize: 250,
       pageToken: undefined,
-      q: '"user-id-1" in owners and mimeType != \'application/vnd.google-apps.folder\'',
+      q: '"me" in owners and mimeType != \'application/vnd.google-apps.folder\'',
     });
 
     expect(step.run).toBeCalledWith('list-files-permissions', expect.any(Function));

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.ts
@@ -81,7 +81,7 @@ export const syncDataProtectionDrive = inngest.createFunction(
               corpora: 'drive',
             }
           : {
-              q: `"${managerUserId}" in owners and mimeType != 'application/vnd.google-apps.folder'`,
+              q: `"me" in owners and mimeType != 'application/vnd.google-apps.folder'`,
             }),
       });
     });


### PR DESCRIPTION
## Description

This fixes a bug where personal drive files would be ignored during sync due to a [bug](https://github.com/elba-security/elba-security/blob/2b4016956383790fd0e7e2435bea11ad5ee6327c/apps/google/src/inngest/functions/data-protection/sync-drive.ts#L84) where we attempted to use user id instead of user email to only keep files owned by the owner of the personal drive
Now instead of relying on email or user id, we can rely on property `me` in `owners` property

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
