### PR TITLE
fix: trigger and await waitForEvent & sendEvent at the same time

### DIFF
--- a/apps/sharepoint/src/inngest/functions/data-protection/sync-sites.ts
+++ b/apps/sharepoint/src/inngest/functions/data-protection/sync-sites.ts
@@ -53,28 +53,27 @@ export const syncSites = inngest.createFunction(
     });
 
     if (siteIds.length) {
-      const eventsWait = siteIds.map((id) =>
-        step.waitForEvent(`wait-for-drives-complete-${id}`, {
-          event: 'sharepoint/drives.sync.completed',
-          timeout: '30d',
-          if: `async.data.organisationId == '${organisationId}' && async.data.siteId == '${id}'`,
-        })
-      );
-
-      await step.sendEvent(
-        'drives-sync-triggered',
-        siteIds.map((id) => ({
-          name: 'sharepoint/drives.sync.triggered',
-          data: {
-            siteId: id,
-            isFirstSync,
-            skipToken: null,
-            organisationId,
-          },
-        }))
-      );
-
-      await Promise.all(eventsWait);
+      await Promise.all([
+        ...siteIds.map((id) =>
+          step.waitForEvent(`wait-for-drives-complete-${id}`, {
+            event: 'sharepoint/drives.sync.completed',
+            timeout: '30d',
+            if: `async.data.organisationId == '${organisationId}' && async.data.siteId == '${id}'`,
+          })
+        ),
+        step.sendEvent(
+          'drives-sync-triggered',
+          siteIds.map((id) => ({
+            name: 'sharepoint/drives.sync.triggered',
+            data: {
+              siteId: id,
+              isFirstSync,
+              skipToken: null,
+              organisationId,
+            },
+          }))
+        ),
+      ]);
     }
 
     if (nextSkipToken) {


### PR DESCRIPTION
## Description

This is a recommendation from Inngest team which might resolve some issues that could occur sometimes. Instead of using a hack to first creating an array of promises using `waitForEvent` and then use `sendEvent` and finally await for the array of promises, they suggested to use `Promise.all()` with both the array of `waitForEvent` & `sendEvent`. There shouldn't be any race, the backend would receive the `waitForEvent` & `sendEvent` and would handle `waitForEvent` first. 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
