### PR TITLE
chore: remove tsbuildinfo incremental file on git ci attempt over 3

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Lint apps and packages
         run: pnpm lint
 
+      - name: Clear tsbuildinfo if retry
+        if: ${{ github.run_attempt > 3 }}
+        run: |
+          find . -name "tsconfig.tsbuildinfo" -type f -delete
+          echo "Cleared all tsconfig.tsbuildinfo files"
+
       - name: Type-check apps and packages
         run: pnpm type-check
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Clear tsbuildinfo if retry
         if: ${{ github.run_attempt > 3 }}
         run: |
-          find . -name "tsconfig.tsbuildinfo" -type f -delete
+          find ./apps -name "tsconfig.tsbuildinfo" -type f -delete
           echo "Cleared all tsconfig.tsbuildinfo files"
 
       - name: Type-check apps and packages

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "type-check": "turbo run type-check",
+    "type-check": "turbo run type-check --output-logs=errors-only",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## Description
1. On `tsc --noEmit` type check , it will create incremental `tsconfig.tsbuildinfo` file, in some cases it is not updating once it encounter type error, the file stays same ant the type error appears again and again, therefore if the error appears again after github try 3, all the `tsconfig.tsbuildinfo` file will be removed and generated again,

Random type error: 
![Screenshot 2024-09-06 at 5 16 05 PM](https://github.com/user-attachments/assets/a9b512cb-a3c7-46c0-90e6-db486ad44bc6)

Solution:
```yaml
 - name: Clear tsbuildinfo if retry
        if: ${{ github.run_attempt > 3 }}
        run: |
          find ./apps -name "tsconfig.tsbuildinfo" -type f -delete
          echo "Cleared all tsconfig.tsbuildinfo files"
```

2.  `--output-logs=errors-only` flag will only log the error rather than all the apps/sub-folder checks.  we can easily identify the error in first glance & we don't need to open each check to find the type error

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
