### PR TITLE
chore: fix inngest pnpm resolution

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -20,7 +20,7 @@
     "@hono/node-server": "^1.2.3",
     "@types/node": "^20",
     "eslint": "^8",
-    "hono": "^4.4.10",
+    "hono": "4.3.2",
     "tsx": "^3.12.2",
     "typescript": "^5.5.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2328,8 +2328,8 @@ importers:
         specifier: ^8
         version: 8.53.0
       hono:
-        specifier: ^4.4.10
-        version: 4.4.10
+        specifier: 4.3.2
+        version: 4.3.2
       tsx:
         specifier: ^3.12.2
         version: 3.14.0
@@ -7930,11 +7930,6 @@ packages:
   /hono@4.3.2:
     resolution: {integrity: sha512-wiZcF5N06tc232U11DnqW6hP8DNoypjsrxslKXfvOqOAkTdh7K1HLZJH/92Mf+urxUTGi96f1w4xx/1Qozoqiw==}
     engines: {node: '>=16.0.0'}
-
-  /hono@4.4.10:
-    resolution: {integrity: sha512-z6918u9rXRU5CCisMHd2uUVoQXcNyUrUMmYY7VH10v4HJG7+hqgMK/G8YNTd13C6s4rBfzF09iz8VpOip9qG3A==}
-    engines: {node: '>=16.0.0'}
-    dev: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}


### PR DESCRIPTION
## Description

Inngest use hono behind the hood, but a different version that was installed by `api-client`. Pnpm was locking two version of inngest and resolving the bad one for apps. It's look like a pnpm bug. This PR should do the trick. Other fix could be to force resolution of hono in each apps package.json, but it's simpler to just downgrade our version of hono in `api-client`.

- fix inngest pnpm resolution

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
