### PR TITLE
chore:  increase the refresh token time interval

### DIFF
--- a/apps/zoom/src/connectors/zoom/auth.ts
+++ b/apps/zoom/src/connectors/zoom/auth.ts
@@ -65,6 +65,9 @@ export const getRefreshToken = async (refreshTokenInfo: string) => {
   });
 
   if (!response.ok) {
+    //log the response body
+    const data: unknown = await response.text();
+    logger.error('Could not refresh token', { error: data });
     throw new ZoomError('Could not refresh token', { response });
   }
 

--- a/apps/zoom/src/inngest/functions/token/refresh-token.ts
+++ b/apps/zoom/src/inngest/functions/token/refresh-token.ts
@@ -35,7 +35,7 @@ export const refreshToken = inngest.createFunction(
   async ({ event, step }) => {
     const { organisationId, expiresAt } = event.data;
 
-    await step.sleepUntil('wait-before-expiration', subMinutes(new Date(expiresAt), 30));
+    await step.sleepUntil('wait-before-expiration', subMinutes(new Date(expiresAt), 10));
 
     const nextExpiresAt = await step.run('refresh-token', async () => {
       const [organisation] = await db


### PR DESCRIPTION
## Description

It return  error code 400 after few refresh,  it seems we are refreshing too early, therefore it is set to refresh before 10min, however I am not sure of the error, I suspect it could be related to this issue , https://devforum.zoom.us/t/cannot-renew-access-token-refresh-token-for-some-users-400-invalid-token/76400 , I added a log to debug 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
