### PR TITLE
fix:  Implemented response cloning to allow multiple reads of the response body

### DIFF
--- a/apps/jira/src/app/install/actions.tsx
+++ b/apps/jira/src/app/install/actions.tsx
@@ -76,8 +76,8 @@ export const install = async (_: FormState, formData: FormData): Promise<FormSta
       const status = error.response?.status;
       // 403: Site temporarily unavailable
       // 503: Your Jira Cloud subscription has been deactivated due to inactivity
-      if (status && [404, 503].includes(status) && error.response?.text()) {
-        const errorText = await error.response.text();
+      if (status && [404, 503].includes(status) && error.response) {
+        const errorText = await error.response.clone().text();
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- we trust the response.text on error
         const errorResult: {


### PR DESCRIPTION
## Description

Fix response body read error using response.clone()

 Implemented response cloning to allow multiple reads of the response body

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
