### PR TITLE
feat: handle region & nango connection id in webhooks

### DIFF
--- a/apps/confluence/src/app/api/webhooks/elba/data-protection/delete-object-permissions/service.test.ts
+++ b/apps/confluence/src/app/api/webhooks/elba/data-protection/delete-object-permissions/service.test.ts
@@ -4,6 +4,8 @@ import { inngest } from '@/inngest/client';
 import { deleteDataProtectionObjectPermissions } from './service';
 
 const spaceEventData = {
+  region: 'eu' as const,
+  nangoConnectionId: null,
   organisationId: 'organisation-id',
   id: 'object-id',
   metadata: {
@@ -20,6 +22,8 @@ const spaceEventData = {
 };
 
 const invalidSpaceEventData = {
+  region: 'eu' as const,
+  nangoConnectionId: null,
   organisationId: 'organisation-id',
   id: 'object-id',
   metadata: {
@@ -44,6 +48,8 @@ const invalidSpaceEventData = {
 };
 
 const pageEventData = {
+  region: 'eu' as const,
+  nangoConnectionId: null,
   organisationId: 'organisation-id',
   id: 'object-id',
   metadata: {
@@ -58,6 +64,8 @@ const pageEventData = {
 };
 
 const invalidPageEventData = {
+  region: 'eu' as const,
+  nangoConnectionId: null,
   organisationId: 'organisation-id',
   id: 'object-id',
   metadata: {

--- a/apps/onedrive/src/app/api/webhooks/elba/data-protection/delete-object-permissions/service.test.ts
+++ b/apps/onedrive/src/app/api/webhooks/elba/data-protection/delete-object-permissions/service.test.ts
@@ -61,8 +61,10 @@ describe('deleteObjectPermissions', () => {
     const response = await mockNextRequest({
       handler,
       body: {
-        id: itemId,
+        region: 'us',
+        nangoConnectionId: null,
         organisationId: organisation.id,
+        id: itemId,
         metadata: {
           userId,
         },

--- a/apps/onedrive/src/app/api/webhooks/elba/data-protection/refresh-object/service.test.ts
+++ b/apps/onedrive/src/app/api/webhooks/elba/data-protection/refresh-object/service.test.ts
@@ -29,8 +29,10 @@ describe('refreshObject', () => {
     const response = await mockNextRequest({
       handler,
       body: {
-        id: itemId,
+        region: 'us',
+        nangoConnectionId: null,
         organisationId: organisation.id,
+        id: itemId,
         metadata: {
           userId,
         },

--- a/apps/onedrive/src/app/api/webhooks/elba/data-protection/start-sync/service.test.ts
+++ b/apps/onedrive/src/app/api/webhooks/elba/data-protection/start-sync/service.test.ts
@@ -33,6 +33,8 @@ describe('startSync', () => {
     const response = await mockNextRequest({
       handler,
       body: {
+        region: 'us',
+        nangoConnectionId: null,
         organisationId: organisation.id,
       },
     });

--- a/apps/sharepoint/src/app/api/webhooks/elba/data-protection/delete-object-permissions/service.test.ts
+++ b/apps/sharepoint/src/app/api/webhooks/elba/data-protection/delete-object-permissions/service.test.ts
@@ -62,8 +62,10 @@ describe('deleteObjectPermissions', () => {
     const response = await mockNextRequest({
       handler,
       body: {
-        id: itemId,
+        region: 'us',
+        nangoConnectionId: null,
         organisationId: organisation.id,
+        id: itemId,
         metadata: {
           siteId,
           driveId,

--- a/apps/sharepoint/src/app/api/webhooks/elba/data-protection/refresh-object/service.test.ts
+++ b/apps/sharepoint/src/app/api/webhooks/elba/data-protection/refresh-object/service.test.ts
@@ -30,8 +30,10 @@ describe('refreshObject', () => {
     const response = await mockNextRequest({
       handler,
       body: {
-        id: itemId,
+        region: 'us',
+        nangoConnectionId: null,
         organisationId: organisation.id,
+        id: itemId,
         metadata: {
           siteId,
           driveId,

--- a/apps/sharepoint/src/app/api/webhooks/elba/data-protection/start-sync/service.test.ts
+++ b/apps/sharepoint/src/app/api/webhooks/elba/data-protection/start-sync/service.test.ts
@@ -33,6 +33,8 @@ describe('startSync', () => {
     const response = await mockNextRequest({
       handler,
       body: {
+        region: 'us',
+        nangoConnectionId: null,
         organisationId: organisation.id,
       },
     });

--- a/packages/schemas/src/authentication.ts
+++ b/packages/schemas/src/authentication.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
+import { baseWebhookSchema } from './common';
 
-export const authenticationRefreshObjectRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  id: z.string().min(1),
-});
+export const authenticationRefreshObjectRequestedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    id: z.string().min(1),
+  })
+);

--- a/packages/schemas/src/common.ts
+++ b/packages/schemas/src/common.ts
@@ -32,3 +32,17 @@ export const baseDeleteRequestSchema = z.union([
 ]);
 
 export type BaseDeleteRequest = zInfer<typeof baseDeleteRequestSchema>;
+
+export const elbaRegions = ['eu', 'us'] as const;
+
+export const elbaRegionSchema = z.enum(elbaRegions);
+
+export type ElbaRegion = zInfer<typeof elbaRegionSchema>;
+
+export const baseWebhookSchema = z.object({
+  organisationId: z.string().uuid(),
+  nangoConnectionId: z.string().min(1).nullable(),
+  region: elbaRegionSchema,
+});
+
+export type BaseWebhookData = zInfer<typeof baseWebhookSchema>;

--- a/packages/schemas/src/data-protection.ts
+++ b/packages/schemas/src/data-protection.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { infer as zInfer } from 'zod';
-import { baseDeleteRequestSchema, jsonSchema } from './common';
+import { baseDeleteRequestSchema, baseWebhookSchema, jsonSchema } from './common';
 
 const basePermissionSchema = z.object({
   id: z.string().min(1),
@@ -53,39 +53,41 @@ export const deleteDataProtectionObjectsSchema = baseDeleteRequestSchema;
 
 export type DeleteDataProtectionObjects = zInfer<typeof deleteDataProtectionObjectsSchema>;
 
-export const dataProtectionContentRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  id: z.string().min(1),
-  metadata: jsonSchema,
-});
+export const dataProtectionContentRequestedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    id: z.string().min(1),
+    metadata: jsonSchema,
+  })
+);
 
-export const dataProtectionStartSyncRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-});
+export const dataProtectionStartSyncRequestedWebhookDataSchema = baseWebhookSchema;
 
-export const dataProtectionObjectDeletedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  id: z.string().min(1),
-  metadata: jsonSchema,
-});
+export const dataProtectionObjectDeletedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    id: z.string().min(1),
+    metadata: jsonSchema,
+  })
+);
 
-export const dataProtectionRefreshObjectRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  id: z.string().min(1),
-  metadata: jsonSchema,
-});
+export const dataProtectionRefreshObjectRequestedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    id: z.string().min(1),
+    metadata: jsonSchema,
+  })
+);
 
-export const dataProtectionDeleteObjectPermissionsRequestedDataSchema = z.object({
-  id: z.string().min(1),
-  organisationId: z.string().uuid(),
-  metadata: jsonSchema,
-  permissions: z.array(
-    z.object({
-      id: z.string().min(1),
-      metadata: jsonSchema,
-    })
-  ),
-});
+export const dataProtectionDeleteObjectPermissionsRequestedDataSchema = baseWebhookSchema.and(
+  z.object({
+    id: z.string().min(1),
+    metadata: jsonSchema,
+    permissions: z.array(
+      z.object({
+        id: z.string().min(1),
+        metadata: jsonSchema,
+      })
+    ),
+  })
+);
 
 export type DataProtectionDeleteObjectPermissionsRequestedData = z.infer<
   typeof dataProtectionDeleteObjectPermissionsRequestedDataSchema

--- a/packages/schemas/src/third-party-apps.ts
+++ b/packages/schemas/src/third-party-apps.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { infer as zInfer } from 'zod';
-import { jsonSchema } from './common';
+import { baseWebhookSchema, jsonSchema } from './common';
 
 export const updateThirdPartyAppsSchema = z.object({
   apps: z.array(
@@ -38,20 +38,20 @@ export const deleteThirdPartyAppsSchema = z.union([
 
 export type DeleteThirdPartyApps = zInfer<typeof deleteThirdPartyAppsSchema>;
 
-export const thirdPartyAppsStartSyncRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-});
+export const thirdPartyAppsStartSyncRequestedWebhookDataSchema = baseWebhookSchema;
 
-export const thirdPartyAppsRefreshObjectRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  userId: z.string(),
-  appId: z.string(),
-  metadata: jsonSchema,
-});
+export const thirdPartyAppsRefreshObjectRequestedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    userId: z.string(),
+    appId: z.string(),
+    metadata: jsonSchema,
+  })
+);
 
-export const thirdPartyAppsDeleteObjectRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  userId: z.string(),
-  appId: z.string(),
-  metadata: jsonSchema,
-});
+export const thirdPartyAppsDeleteObjectRequestedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    userId: z.string(),
+    appId: z.string(),
+    metadata: jsonSchema,
+  })
+);

--- a/packages/schemas/src/users.ts
+++ b/packages/schemas/src/users.ts
@@ -1,6 +1,6 @@
 import type { infer as zInfer } from 'zod';
 import { z } from 'zod';
-import { baseDeleteRequestSchema } from './common';
+import { baseDeleteRequestSchema, baseWebhookSchema } from './common';
 
 export const updateUsersSchema = z.object({
   users: z.array(
@@ -17,10 +17,11 @@ export const updateUsersSchema = z.object({
   ),
 });
 
-export const usersDeleteUsersRequestedWebhookDataSchema = z.object({
-  organisationId: z.string().uuid(),
-  ids: z.array(z.string().min(1)),
-});
+export const usersDeleteUsersRequestedWebhookDataSchema = baseWebhookSchema.and(
+  z.object({
+    ids: z.array(z.string().min(1)),
+  })
+);
 
 export type UpdateUsers = zInfer<typeof updateUsersSchema>;
 

--- a/packages/sdk/src/webhooks/event-data.test.ts
+++ b/packages/sdk/src/webhooks/event-data.test.ts
@@ -12,19 +12,18 @@ describe('parseWebhookEventData', () => {
   });
 
   test('should returns the event data when the payload is valid', () => {
-    const data = { organisationId: '139ed8eb-2f8c-4784-b330-019d57737f06', someExtraData: 'foo' };
-    const result = parseWebhookEventData('data_protection.start_sync_requested', data);
-
-    expect(result).toStrictEqual({ organisationId: data.organisationId });
-  });
-
-  test('should returns the event data when the data is instance of URLSearchParams and is valid', () => {
-    const data = new URLSearchParams({
+    const data = {
+      region: 'eu',
+      nangoConnectionId: null,
       organisationId: '139ed8eb-2f8c-4784-b330-019d57737f06',
       someExtraData: 'foo',
-    });
+    };
     const result = parseWebhookEventData('data_protection.start_sync_requested', data);
 
-    expect(result).toStrictEqual({ organisationId: data.get('organisationId') });
+    expect(result).toStrictEqual({
+      region: 'eu',
+      nangoConnectionId: null,
+      organisationId: data.organisationId,
+    });
   });
 });

--- a/packages/sdk/src/webhooks/event-data.ts
+++ b/packages/sdk/src/webhooks/event-data.ts
@@ -34,7 +34,7 @@ export const parseWebhookEventData = <T extends WebhookEvent>(
   event: T,
   data: unknown
 ): zInfer<(typeof eventDataSchema)[T]> => {
-  const eventDataParseResult = eventDataSchema[event].safeParse(formatData(data));
+  const eventDataParseResult = eventDataSchema[event].safeParse(data);
 
   if (!eventDataParseResult.success) {
     throw new ElbaError('Could not validate webhook event data', {
@@ -43,11 +43,4 @@ export const parseWebhookEventData = <T extends WebhookEvent>(
   }
 
   return eventDataParseResult.data;
-};
-
-const formatData = (data: unknown) => {
-  if (data instanceof URLSearchParams) {
-    return Object.fromEntries(data.entries());
-  }
-  return data;
 };


### PR DESCRIPTION
## Description

This handle region & nango connection id in webhooks. The webhooks can no retrieve them using `region` & `nangoConnectionId`

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
