### PR TITLE
feat: handle error type and metadata in connection status

### DIFF
--- a/apps/15five/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/15five/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/15five/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/15five/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/aircall/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/aircall/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/aircall/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/aircall/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/asana/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/asana/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/asana/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/asana/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/azuredevops/src/inngest/functions/organisation/remove-organisation.test.ts
+++ b/apps/azuredevops/src/inngest/functions/organisation/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/azuredevops/src/inngest/functions/organisation/remove-organisation.ts
+++ b/apps/azuredevops/src/inngest/functions/organisation/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient({ organisationId, region: organisation.region });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/box/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/box/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/box/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/box/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/calendly/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/calendly/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/calendly/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/calendly/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/confluence/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/confluence/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -39,7 +39,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/confluence/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/confluence/src/inngest/functions/organisations/remove-organisation.ts
@@ -35,7 +35,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient(organisationId, organisation.region);
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/datadog/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/datadog/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
     const elbaInstance = elba.mock.results.at(0)?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
     await expect(
       db.select().from(organisationsTable).where(eq(organisationsTable.id, organisation.id))

--- a/apps/datadog/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/datadog/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/dbtlabs/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/dbtlabs/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/dbtlabs/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/dbtlabs/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/docusign/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/docusign/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -48,7 +48,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/docusign/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/docusign/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/doppler/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/doppler/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -44,7 +44,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/doppler/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/doppler/src/inngest/functions/organisations/remove-organisation.ts
@@ -42,7 +42,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/dropbox/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/dropbox/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/dropbox/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/dropbox/src/inngest/functions/organisations/remove-organisation.ts
@@ -40,7 +40,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/fivetran/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/fivetran/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -50,7 +50,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/fivetran/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/fivetran/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/front/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/front/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/front/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/front/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/github/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/github/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/github/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/github/src/inngest/functions/organisations/remove-organisation.ts
@@ -43,7 +43,7 @@ export const removeOrganisation = inngest.createFunction(
       baseUrl: env.ELBA_API_BASE_URL,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/google/src/inngest/functions/common/remove-organisation.test.ts
+++ b/apps/google/src/inngest/functions/common/remove-organisation.test.ts
@@ -54,6 +54,6 @@ describe('remove-organisation', () => {
 
     const elbaInstance = elba.mock.results[0]?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
-    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ hasError: true });
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ errorType: 'unauthorized' });
   });
 });

--- a/apps/google/src/inngest/functions/common/remove-organisation.ts
+++ b/apps/google/src/inngest/functions/common/remove-organisation.ts
@@ -45,7 +45,7 @@ export const removeOrganisation = inngest.createFunction(
     if (organisation) {
       logger.info('Google organisation deleted', { organisationId, region: organisation.region });
       const elba = getElbaClient({ organisationId, region: organisation.region });
-      await elba.connectionStatus.update({ hasError: true });
+      await elba.connectionStatus.update({ errorType: 'unauthorized' });
     }
 
     return { status: 'deleted' };

--- a/apps/gusto/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/gusto/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/gusto/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/gusto/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/harvest/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/harvest/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/harvest/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/harvest/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/hubspot/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/hubspot/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -51,7 +51,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/hubspot/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/hubspot/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/intercom/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/intercom/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/intercom/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/intercom/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/jira/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/jira/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
     const elbaInstance = elba.mock.results.at(0)?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
     await expect(
       db.select().from(organisationsTable).where(eq(organisationsTable.id, organisation.id))

--- a/apps/jira/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/jira/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/linear/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/linear/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/linear/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/linear/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/microsoft/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/microsoft/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/microsoft/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/microsoft/src/inngest/functions/organisations/remove-organisation.ts
@@ -29,7 +29,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient(organisationId, organisation.region);
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/notion/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/notion/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/notion/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/notion/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/onedrive/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/onedrive/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -72,7 +72,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/onedrive/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/onedrive/src/inngest/functions/organisations/remove-organisation.ts
@@ -57,7 +57,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient({ organisationId, region: organisation.region });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/openai/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/openai/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -45,7 +45,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/openai/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/openai/src/inngest/functions/organisations/remove-organisation.ts
@@ -28,7 +28,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient(organisationId, organisation.region);
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/salesforce/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/salesforce/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,7 +47,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/salesforce/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/salesforce/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/segment/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/segment/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/segment/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/segment/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/sentry/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/sentry/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -49,7 +49,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/sentry/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/sentry/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -73,7 +73,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.ts
@@ -57,7 +57,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient({ organisationId, region: organisation.region });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/slack/src/inngest/functions/slack/event-handlers/app-uninstalled.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/app-uninstalled.test.ts
@@ -80,7 +80,7 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
     const elbaInstance = elba.mock.results[0]?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     expect(step.sendEvent).toBeCalledTimes(0);

--- a/apps/slack/src/inngest/functions/slack/event-handlers/app-uninstalled.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/app-uninstalled.ts
@@ -21,7 +21,7 @@ export const appUninstalledHandler: SlackEventHandler<'app_uninstalled'> = async
 
   if (team) {
     const elbaClient = createElbaClient(team.elbaOrganisationId, team.elbaRegion);
-    await elbaClient.connectionStatus.update({ hasError: true });
+    await elbaClient.connectionStatus.update({ errorType: 'unauthorized' });
   }
 
   logger.info('Slack app uninstalled', { teamId, team });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/user-change.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/user-change.test.ts
@@ -419,7 +419,7 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
 
     const elbaInstance = elba.mock.results[0]?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
-    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ errorType: 'unauthorized' });
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ errorType: 'not_admin' });
     expect(elbaInstance?.users.update).toBeCalledTimes(0);
     expect(elbaInstance?.users.delete).toBeCalledTimes(0);
 

--- a/apps/slack/src/inngest/functions/slack/event-handlers/user-change.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/user-change.test.ts
@@ -419,7 +419,7 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
 
     const elbaInstance = elba.mock.results[0]?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
-    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ hasError: true });
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ errorType: 'unauthorized' });
     expect(elbaInstance?.users.update).toBeCalledTimes(0);
     expect(elbaInstance?.users.delete).toBeCalledTimes(0);
 

--- a/apps/slack/src/inngest/functions/slack/event-handlers/user-change.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/user-change.ts
@@ -35,7 +35,7 @@ export const userChangeHandler: SlackEventHandler<'user_change'> = async ({
     const token = await decrypt(team.token);
     await new SlackAPIClient().auth.revoke({ token });
     await db.delete(teamsTable).where(eq(teamsTable.id, teamId));
-    await elbaClient.connectionStatus.update({ hasError: true });
+    await elbaClient.connectionStatus.update({ errorType: 'unauthorized' });
 
     return { message: 'App uninstalled, user is not admin anymore', teamId, user };
   }

--- a/apps/slack/src/inngest/functions/slack/event-handlers/user-change.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/user-change.ts
@@ -35,7 +35,7 @@ export const userChangeHandler: SlackEventHandler<'user_change'> = async ({
     const token = await decrypt(team.token);
     await new SlackAPIClient().auth.revoke({ token });
     await db.delete(teamsTable).where(eq(teamsTable.id, teamId));
-    await elbaClient.connectionStatus.update({ errorType: 'unauthorized' });
+    await elbaClient.connectionStatus.update({ errorType: 'not_admin' });
 
     return { message: 'App uninstalled, user is not admin anymore', teamId, user };
   }

--- a/apps/statsig/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/statsig/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -44,7 +44,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/statsig/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/statsig/src/inngest/functions/organisations/remove-organisation.ts
@@ -42,7 +42,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/teams/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/teams/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -71,7 +71,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/teams/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/teams/src/inngest/functions/organisations/remove-organisation.ts
@@ -46,7 +46,7 @@ export const removeOrganisation = inngest.createFunction(
 
     const elba = createElbaClient(organisationId, organisation.region);
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/yousign/src/inngest/functions/organisation/remove-organisation.test.ts
+++ b/apps/yousign/src/inngest/functions/organisation/remove-organisation.test.ts
@@ -44,7 +44,7 @@ describe('remove-organisation', () => {
     const elbaInstance = elba.mock.results.at(0)?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
     await expect(
       db.select().from(organisationsTable).where(eq(organisationsTable.id, organisation.id))

--- a/apps/yousign/src/inngest/functions/organisation/remove-organisation.ts
+++ b/apps/yousign/src/inngest/functions/organisation/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/zendesk/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/zendesk/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -50,7 +50,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/zendesk/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/zendesk/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/apps/zoom/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/zoom/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -46,7 +46,7 @@ describe('remove-organisation', () => {
 
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
-      hasError: true,
+      errorType: 'unauthorized',
     });
 
     await expect(

--- a/apps/zoom/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/zoom/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       region: organisation.region,
     });
 
-    await elba.connectionStatus.update({ hasError: true });
+    await elba.connectionStatus.update({ errorType: 'unauthorized' });
 
     await db.delete(organisationsTable).where(eq(organisationsTable.id, organisationId));
   }

--- a/docs/api/connection-status/update-status.md
+++ b/docs/api/connection-status/update-status.md
@@ -12,10 +12,11 @@ POST /api/rest/connection-status
 
 Supported attributes:
 
-| Attribute                   | Type    | Required | Description                                 |
-| --------------------------- | ------- | -------- | ------------------------------------------- |
-| `organisationId` **(uuid)** | string  | Yes      | Unique identifier for the organisation.     |
-| `hasError`                  | boolean | Yes      | Indicates if there is an error with access. |
+| Attribute                   | Type           | Required | Description                                                                                                                           |
+| --------------------------- | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `organisationId` **(uuid)** | string         | Yes      | Unique identifier for the organisation.                                                                                               |
+| `errorType`                 | string or null | Yes      | The type of error. Supported values are `not_admin`, `unauthorized`, `unknown`, `unsupported_plan`. Use `null` when there is no error |
+| `errorMetadata`             | object         | No       | The metadata related to the error.                                                                                                    |
 
 Example requests:
 
@@ -29,12 +30,16 @@ curl
   --header "Content-Type: application/json" \
   --data '{
     "organisationId": "organisation-id",
-    "hasError": true
+    "errorType": "unknown"
+    "errorMetadata": {"message": "An unexpected error occurred"}
   }'
 ```
 
 #### elba SDK
 
 ```javascript
-elba.connectionStatus.update({ hasError: true });
+elba.connectionStatus.update({
+  errorType: 'unknown',
+  errorMetadata: { message: 'An unexpected error occurred' },
+});
 ```

--- a/packages/schemas/src/connection-status.ts
+++ b/packages/schemas/src/connection-status.ts
@@ -1,8 +1,19 @@
 import type { infer as zInfer } from 'zod';
 import { z } from 'zod';
+import { jsonSchema } from './common';
+
+export const connectionErrorTypeSchema = z.enum([
+  'not_admin',
+  'unauthorized',
+  'unknown',
+  'unsupported_plan',
+]);
+
+export type ConnectionErrorType = zInfer<typeof connectionErrorTypeSchema>;
 
 export const updateConnectionStatusSchema = z.object({
-  hasError: z.boolean(),
+  errorType: connectionErrorTypeSchema.nullable(),
+  errorMetadata: jsonSchema,
 });
 
 export type UpdateConnectionStatus = zInfer<typeof updateConnectionStatusSchema>;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -195,5 +195,5 @@ _Used when the integration retrieve data from SaaS using webhook._
 Update the connection status of the elba organisation with the SaaS:
 
 ```ts
-elba.connectionStatus.update(hasError);
+elba.connectionStatus.update({ errorType, errorMetadata });
 ```

--- a/packages/sdk/src/elba.test.ts
+++ b/packages/sdk/src/elba.test.ts
@@ -153,7 +153,9 @@ describe('connection status', () => {
   describe('update', () => {
     test('should call the right endpoint and return the response data', async () => {
       const elba = new Elba(options);
-      await expect(elba.connectionStatus.update({ hasError: true })).resolves.toStrictEqual({
+      await expect(
+        elba.connectionStatus.update({ errorType: 'unauthorized' })
+      ).resolves.toStrictEqual({
         success: true,
       });
     });

--- a/packages/sdk/src/resources/connection-status/types.ts
+++ b/packages/sdk/src/resources/connection-status/types.ts
@@ -1,3 +1,5 @@
+export type { ConnectionErrorType } from '@elba-security/schemas';
+
 export type ConnectionStatusUpdateResult = {
   success: boolean;
 };


### PR DESCRIPTION
## Description

This updates the schemas and sdk packages to accept error type and metadata when updating the connection status.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
