### PR TITLE
feat: add endpoint to list organisations with active connections

### DIFF
--- a/apps/google/src/inngest/functions/authentication/refresh-object.test.ts
+++ b/apps/google/src/inngest/functions/authentication/refresh-object.test.ts
@@ -4,6 +4,7 @@ import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import * as googleUsers from '@/connectors/google/users';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
+import { env } from '@/common/env/server';
 import { getOrganisation } from '../common/get-organisation';
 import { refreshAuthenticationObject } from './refresh-object';
 
@@ -66,8 +67,8 @@ describe('refresh-authentication-object', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/common/remove-organisation.test.ts
+++ b/apps/google/src/inngest/functions/common/remove-organisation.test.ts
@@ -2,6 +2,7 @@ import { expect, test, describe } from 'vitest';
 import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
 import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
+import { env } from '@/common/env/server';
 import { removeOrganisation } from './remove-organisation';
 
 const setup = createInngestFunctionMock(
@@ -46,8 +47,8 @@ describe('remove-organisation', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/data-protection/refresh-object.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/refresh-object.test.ts
@@ -5,6 +5,7 @@ import { organisationsTable, usersTable } from '@/database/schema';
 import * as googlePermissions from '@/connectors/google/permissions';
 import * as googleFiles from '@/connectors/google/files';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
+import { env } from '@/common/env/server';
 import { refreshDataProtectionObject } from './refresh-object';
 
 const setup = createInngestFunctionMock(
@@ -71,8 +72,8 @@ describe('refresh-data-protection-object', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });
@@ -170,8 +171,8 @@ describe('refresh-data-protection-object', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
@@ -3,6 +3,7 @@ import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils'
 import * as googleFiles from '@/connectors/google/files';
 import * as googlePermissions from '@/connectors/google/permissions';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
+import { env } from '@/common/env/server';
 import { syncDataProtectionDrive } from './sync-drive';
 
 const setup = createInngestFunctionMock(
@@ -92,8 +93,8 @@ describe('sync-data-protection-drive', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });
@@ -250,8 +251,8 @@ describe('sync-data-protection-drive', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/data-protection/sync.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync.test.ts
@@ -5,6 +5,7 @@ import { organisationsTable } from '@/database/schema';
 import * as googleDrives from '@/connectors/google/drives';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
 import { GoogleDriveAccessDenied } from '@/connectors/google/errors';
+import { env } from '@/common/env/server';
 import { getOrganisation } from '../common/get-organisation';
 import { syncDataProtection } from './sync';
 
@@ -95,8 +96,8 @@ describe('sync-data-protection', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/third-party-apps/refresh-object.test.ts
+++ b/apps/google/src/inngest/functions/third-party-apps/refresh-object.test.ts
@@ -4,6 +4,7 @@ import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import * as googleTokens from '@/connectors/google/tokens';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
+import { env } from '@/common/env/server';
 import { getOrganisation } from '../common/get-organisation';
 import { refreshThirdPartyAppsObject } from './refresh-object';
 
@@ -58,8 +59,8 @@ describe('refresh-third-party-apps-object', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });
@@ -132,8 +133,8 @@ describe('refresh-third-party-apps-object', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/third-party-apps/sync.test.ts
+++ b/apps/google/src/inngest/functions/third-party-apps/sync.test.ts
@@ -4,6 +4,7 @@ import { db } from '@/database/client';
 import { organisationsTable, usersTable } from '@/database/schema';
 import * as GoogleTokens from '@/connectors/google/tokens';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
+import { env } from '@/common/env/server';
 import { getOrganisation } from '../common/get-organisation';
 import { syncThirdPartyApps } from './sync';
 
@@ -98,8 +99,8 @@ describe('sync-third-party-apps', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });
@@ -235,8 +236,8 @@ describe('sync-third-party-apps', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/google/src/inngest/functions/users/sync.test.ts
+++ b/apps/google/src/inngest/functions/users/sync.test.ts
@@ -5,6 +5,7 @@ import { organisationsTable, usersTable } from '@/database/schema';
 import * as googleUsers from '@/connectors/google/users';
 import { spyOnGoogleServiceAccountClient } from '@/connectors/google/__mocks__/clients';
 import { GoogleUserNotAdminError } from '@/connectors/google/errors';
+import { env } from '@/common/env/server';
 import { getOrganisation } from '../common/get-organisation';
 import { syncUsers } from './sync';
 
@@ -88,8 +89,8 @@ describe('sync-users', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });
@@ -253,8 +254,8 @@ describe('sync-users', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
-      baseUrl: 'https://elba.local/api',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000000',
       region: 'eu',
     });

--- a/apps/slack/src/app/api/webhook/elba/refresh-data-protection-object/service.test.ts
+++ b/apps/slack/src/app/api/webhook/elba/refresh-data-protection-object/service.test.ts
@@ -4,6 +4,7 @@ import { spyOnElba } from '@elba-security/test-utils';
 import { db } from '@/database/client';
 import { conversationsTable, teamsTable } from '@/database/schema';
 import * as crypto from '@/common/crypto';
+import { env } from '@/common/env';
 import { refreshDataProtectionObject } from './service';
 
 describe('refresh-data-protection-object', () => {
@@ -102,7 +103,8 @@ describe('refresh-data-protection-object', () => {
 
       expect(elba).toBeCalledTimes(1);
       expect(elba).toBeCalledWith({
-        apiKey: 'elba-api-key',
+        apiKey: env.ELBA_API_KEY,
+        baseUrl: env.ELBA_API_BASE_URL,
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
       });
@@ -202,7 +204,8 @@ describe('refresh-data-protection-object', () => {
 
       expect(elba).toBeCalledTimes(1);
       expect(elba).toBeCalledWith({
-        apiKey: 'elba-api-key',
+        apiKey: env.ELBA_API_KEY,
+        baseUrl: env.ELBA_API_BASE_URL,
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
       });
@@ -293,7 +296,8 @@ describe('refresh-data-protection-object', () => {
 
       expect(elba).toBeCalledTimes(1);
       expect(elba).toBeCalledWith({
-        apiKey: 'elba-api-key',
+        apiKey: env.ELBA_API_KEY,
+        baseUrl: env.ELBA_API_BASE_URL,
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
       });
@@ -397,7 +401,8 @@ describe('refresh-data-protection-object', () => {
 
       expect(elba).toBeCalledTimes(1);
       expect(elba).toBeCalledWith({
-        apiKey: 'elba-api-key',
+        apiKey: env.ELBA_API_KEY,
+        baseUrl: env.ELBA_API_BASE_URL,
         organisationId: '00000000-0000-0000-0000-000000000001',
         region: 'eu',
       });

--- a/apps/slack/src/connectors/elba/client.ts
+++ b/apps/slack/src/connectors/elba/client.ts
@@ -5,6 +5,7 @@ export const createElbaClient = (organisationId: string, region: string) => {
   return new Elba({
     apiKey: env.ELBA_API_KEY,
     organisationId,
+    baseUrl: env.ELBA_API_BASE_URL,
     region,
   });
 };

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.test.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-messages.test.ts
@@ -4,6 +4,7 @@ import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils'
 import * as crypto from '@/common/crypto';
 import { db } from '@/database/client';
 import { conversationsTable, teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { synchronizeConversationMessages } from './synchronize-conversation-messages';
 
 const setup = createInngestFunctionMock(
@@ -107,7 +108,8 @@ describe('synchronize-conversation-messages', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });
@@ -271,7 +273,8 @@ describe('synchronize-conversation-messages', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.test.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversation-thread-messages.test.ts
@@ -4,6 +4,7 @@ import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils'
 import * as crypto from '@/common/crypto';
 import { db } from '@/database/client';
 import { conversationsTable, teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { synchronizeConversationThreadMessages } from './synchronize-conversation-thread-messages';
 
 const setup = createInngestFunctionMock(
@@ -105,7 +106,8 @@ describe('synchronize-conversation-thread-messages', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });
@@ -246,7 +248,8 @@ describe('synchronize-conversation-thread-messages', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/conversations/synchronize-conversations.test.ts
+++ b/apps/slack/src/inngest/functions/conversations/synchronize-conversations.test.ts
@@ -4,6 +4,7 @@ import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils'
 import * as crypto from '@/common/crypto';
 import { db } from '@/database/client';
 import { conversationsTable, teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { synchronizeConversations } from './synchronize-conversations';
 
 const setup = createInngestFunctionMock(
@@ -313,7 +314,8 @@ describe('synchronize-conversations', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/app-uninstalled.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/app-uninstalled.test.ts
@@ -3,6 +3,7 @@ import type { SlackEvent } from '@slack/bolt';
 import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
 import { db } from '@/database/client';
 import { teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { handleSlackWebhookEvent } from '../handle-slack-webhook-event';
 
 const setup = createInngestFunctionMock(
@@ -72,7 +73,8 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/message/message-deleted.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/message/message-deleted.test.ts
@@ -3,6 +3,7 @@ import type { SlackEvent } from '@slack/bolt';
 import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
 import { db } from '@/database/client';
 import { teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { handleSlackWebhookEvent } from '../../handle-slack-webhook-event';
 import type { SlackMessageSubtype } from './types';
 
@@ -54,7 +55,8 @@ describe(`handle-slack-webhook-event ${eventType} ${messageSubtype}`, () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/message/message.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/message/message.test.ts
@@ -3,6 +3,7 @@ import type { SlackEvent } from '@slack/bolt';
 import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
 import { db } from '@/database/client';
 import { conversationsTable, teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { handleSlackWebhookEvent } from '../../handle-slack-webhook-event';
 
 const setup = createInngestFunctionMock(
@@ -140,7 +141,8 @@ describe(`handle-slack-webhook-event ${eventType} generic`, () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/slack/event-handlers/user-change.test.ts
+++ b/apps/slack/src/inngest/functions/slack/event-handlers/user-change.test.ts
@@ -5,6 +5,7 @@ import * as slack from 'slack-web-api-client';
 import { db } from '@/database/client';
 import { teamsTable } from '@/database/schema';
 import * as crypto from '@/common/crypto';
+import { env } from '@/common/env';
 import { handleSlackWebhookEvent } from '../handle-slack-webhook-event';
 
 const setup = createInngestFunctionMock(
@@ -111,7 +112,8 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });
@@ -216,7 +218,8 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });
@@ -412,7 +415,8 @@ describe(`handle-slack-webhook-event ${eventType}`, () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/apps/slack/src/inngest/functions/users/synchronize-users.test.ts
+++ b/apps/slack/src/inngest/functions/users/synchronize-users.test.ts
@@ -4,6 +4,7 @@ import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils'
 import * as crypto from '@/common/crypto';
 import { db } from '@/database/client';
 import { teamsTable } from '@/database/schema';
+import { env } from '@/common/env';
 import { synchronizeUsers } from './synchronize-users';
 
 const setup = createInngestFunctionMock(synchronizeUsers, 'slack/users.sync.requested');
@@ -89,7 +90,8 @@ describe('synchronize-users', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });
@@ -186,7 +188,8 @@ describe('synchronize-users', () => {
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({
-      apiKey: 'elba-api-key',
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
       organisationId: '00000000-0000-0000-0000-000000000001',
       region: 'eu',
     });

--- a/docs/api/connection-status/update-status.md
+++ b/docs/api/connection-status/update-status.md
@@ -25,7 +25,7 @@ Example requests:
 ```shell
 curl
   --request POST \
-  --url "https://admin.elba.ninja/api/rest/connection-status" \
+  --url "https://api.elba.ninja/api/rest/connection-status" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --header "Content-Type: application/json" \
   --data '{

--- a/docs/api/data-protection/delete-objects.md
+++ b/docs/api/data-protection/delete-objects.md
@@ -27,7 +27,7 @@ Example request for deletion by `ids`:
 ```shell
 curl
   --request DELETE \
-  --url "https://admin.elba.ninja/api/rest/data-protection/objects" \
+  --url "https://api.elba.ninja/api/rest/data-protection/objects" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --header "Content-Type: application/json" \
   --data '{
@@ -41,7 +41,7 @@ Example request for deletion by `syncedBefore`:
 ```shell
 curl
   --request DELETE \
-  --url "https://admin.elba.ninja/api/rest/data-protection/objects" \
+  --url "https://api.elba.ninja/api/rest/data-protection/objects" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --header "Content-Type: application/json" \
   --data '{

--- a/docs/api/data-protection/update-objects.md
+++ b/docs/api/data-protection/update-objects.md
@@ -41,7 +41,7 @@ Example requests:
 ```shell
 curl
   --request POST \
-  --url "https://admin.elba.ninja/api/rest/data-protection/objects" \
+  --url "https://api.elba.ninja/api/rest/data-protection/objects" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --data '{

--- a/docs/api/organisations/list-organisations.md
+++ b/docs/api/organisations/list-organisations.md
@@ -1,0 +1,47 @@
+## Get organisations
+
+This endpoint is used to get organisations with an active integration connection.
+
+### GET
+
+This method allows to get a list of active organisations identifiers.
+
+```text
+GET /api/rest/organisations
+```
+
+If successful, returns [`200`](rest/index.md#status-codes) and the following response attributes:
+
+Example requests:
+
+#### CURL
+
+```shell
+curl --request POST \
+  --url "https://admin.elba.ninja/api/rest/organisations" \
+  --header "Authorization: Bearer <ELBA_API_KEY>" \
+```
+
+#### elba SDK
+
+```javascript
+elba.organisations.list();
+```
+
+Successful response:
+
+| Attribute                           | Type   | Description                            |
+| ----------------------------------- | ------ | -------------------------------------- |
+| `organisations[].id` **(uuid)**     | string | The organisation ID.                   |
+| `organisations[].nangoConnectionId` | string | The Nango connection ID. Can be `null` |
+
+```json
+{
+  "organisations": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "nangoConnectionId": null
+    }
+  ]
+}
+```

--- a/docs/api/organisations/list-organisations.md
+++ b/docs/api/organisations/list-organisations.md
@@ -17,9 +17,9 @@ Example requests:
 #### CURL
 
 ```shell
-curl --request POST \
-  --url "https://admin.elba.ninja/api/rest/organisations" \
-  --header "Authorization: Bearer <ELBA_API_KEY>" \
+curl --request GET \
+  --url "https://api.elba.ninja/api/rest/organisations" \
+  --header "Authorization: Bearer <ELBA_API_KEY>"
 ```
 
 #### elba SDK

--- a/docs/api/third-party-apps/delete-objects.md
+++ b/docs/api/third-party-apps/delete-objects.md
@@ -24,7 +24,7 @@ Example requests:
 ```shell
 curl
   --request DELETE \
-  --url "https://admin.elba.ninja/api/rest/third-party-apps/objects" \
+  --url "https://api.elba.ninja/api/rest/third-party-apps/objects" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --header "Content-Type: application/json" \
   --data '{

--- a/docs/api/third-party-apps/update-objects.md
+++ b/docs/api/third-party-apps/update-objects.md
@@ -36,7 +36,7 @@ Example requests:
 ```shell
 curl
   --request POST \
-  --url "https://admin.elba.ninja/api/rest/third-party-apps/objects" \
+  --url "https://api.elba.ninja/api/rest/third-party-apps/objects" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --data '{

--- a/docs/api/users/delete-users.md
+++ b/docs/api/users/delete-users.md
@@ -32,7 +32,7 @@ Example request for deletion by user `ids`:
 
 ```shell
 curl --request DELETE \
-  --url "https://admin.elba.ninja/api/rest/users" \
+  --url "https://api.elba.ninja/api/rest/users" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --data '{
@@ -46,7 +46,7 @@ Example request for deletion by `syncedBefore`:
 ```shell
 curl
   --request DELETE \
-  --url "https://admin.elba.ninja/api/rest/users" \
+  --url "https://api.elba.ninja/api/rest/users" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --data '{

--- a/docs/api/users/update-users.md
+++ b/docs/api/users/update-users.md
@@ -33,7 +33,7 @@ Example requests:
 
 ```shell
 curl --request POST \
-  --url "https://admin.elba.ninja/api/rest/users" \
+  --url "https://api.elba.ninja/api/rest/users" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer <ELBA_API_KEY>" \
   --data '{

--- a/packages/api-client/src/routes/index.ts
+++ b/packages/api-client/src/routes/index.ts
@@ -1,16 +1,19 @@
 import { connectionStatusRoutes } from './connection-status';
 import { dataProtectionRoutes } from './data-protection';
+import { organisationsRoutes } from './organisations';
 import { thirdPartyAppsRoutes } from './third-party-apps';
 import { usersRoutes } from './users';
 
 export * from './connection-status';
 export * from './data-protection';
+export * from './organisations';
 export * from './third-party-apps';
 export * from './users';
 
 export const elbaApiRoutes = [
   ...connectionStatusRoutes,
   ...dataProtectionRoutes,
+  ...organisationsRoutes,
   ...thirdPartyAppsRoutes,
   ...usersRoutes,
 ];

--- a/packages/api-client/src/routes/organisations.ts
+++ b/packages/api-client/src/routes/organisations.ts
@@ -1,0 +1,24 @@
+import { createRoute } from '../utils';
+
+const path = '/organisations';
+
+export const listOrganisations = createRoute({
+  path,
+  method: 'get',
+  handler: () => {
+    return Response.json({
+      organisations: [
+        {
+          id: '00000000-0000-0000-0000-000000000001',
+          nangoConnectionId: 'nango-connection-id',
+        },
+        {
+          id: '00000000-0000-0000-0000-000000000002',
+          nangoConnectionId: null,
+        },
+      ],
+    });
+  },
+});
+
+export const organisationsRoutes = [listOrganisations];

--- a/packages/sdk/src/elba.test.ts
+++ b/packages/sdk/src/elba.test.ts
@@ -161,3 +161,23 @@ describe('connection status', () => {
     });
   });
 });
+
+describe('organisations', () => {
+  describe('list', () => {
+    test('should call the right endpoint and return the response data', async () => {
+      const elba = new Elba(options);
+      await expect(elba.organisations.list()).resolves.toStrictEqual({
+        organisations: [
+          {
+            id: '00000000-0000-0000-0000-000000000001',
+            nangoConnectionId: 'nango-connection-id',
+          },
+          {
+            id: '00000000-0000-0000-0000-000000000002',
+            nangoConnectionId: null,
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/sdk/src/elba.ts
+++ b/packages/sdk/src/elba.ts
@@ -1,7 +1,7 @@
-import { ElbaError } from './error';
 import { RequestSender } from './request-sender';
 import { ConnectionStatusClient } from './resources/connection-status/client';
 import { DataProtectionClient } from './resources/data-protection/client';
+import { OrganisationsClient } from './resources/organisations/client';
 import { ThirdPartyAppsClient } from './resources/third-party-apps/client';
 import { UsersClient } from './resources/users/client';
 import type { ElbaOptions } from './types';
@@ -9,23 +9,19 @@ import type { ElbaOptions } from './types';
 export class Elba {
   readonly connectionStatus: ConnectionStatusClient;
   readonly dataProtection: DataProtectionClient;
+  readonly organisations: OrganisationsClient;
   readonly thirdPartyApps: ThirdPartyAppsClient;
   readonly users: UsersClient;
 
   constructor(options: ElbaOptions) {
-    const baseUrl = options.baseUrl ?? process.env.ELBA_API_BASE_URL;
-    if (!baseUrl) {
-      throw new ElbaError(
-        'Missing baseUrl: it should be either provided with Elba options or configured as process.env.ELBA_API_BASE_URL'
-      );
-    }
     const requestSender = new RequestSender({
       ...options,
-      baseUrl: baseUrl.replace('{REGION}', options.region),
+      baseUrl: options.baseUrl.replace('{REGION}', options.region),
     });
     this.connectionStatus = new ConnectionStatusClient(requestSender);
     this.dataProtection = new DataProtectionClient(requestSender);
-    this.users = new UsersClient(requestSender);
+    this.organisations = new OrganisationsClient(requestSender);
     this.thirdPartyApps = new ThirdPartyAppsClient(requestSender);
+    this.users = new UsersClient(requestSender);
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,5 +5,6 @@ export * from './webhooks';
 
 export type * from './resources/connection-status/types';
 export type * from './resources/data-protection/types';
+export type * from './resources/organisations/types';
 export type * from './resources/third-party-apps/types';
 export type * from './resources/users/types';

--- a/packages/sdk/src/request-sender.ts
+++ b/packages/sdk/src/request-sender.ts
@@ -2,7 +2,7 @@ import { elbaApiErrorResponseSchema } from '@elba-security/schemas';
 import { type ElbaApiError, ElbaError } from './error';
 import type { ElbaOptions } from './types';
 
-export type RequestSenderOptions = Required<Omit<ElbaOptions, 'region'>>;
+export type RequestSenderOptions = Omit<ElbaOptions, 'region'>;
 
 export type ElbaResponse = Omit<Response, 'json'> & {
   json: <T = unknown>() => Promise<T>;
@@ -10,12 +10,12 @@ export type ElbaResponse = Omit<Response, 'json'> & {
 
 export type ElbaRequestInit<D extends Record<string, unknown>> = {
   method?: string;
-  data: D;
+  data?: D;
 };
 
 export class RequestSender {
   private readonly baseUrl: string;
-  private readonly organisationId: string;
+  private readonly organisationId?: string;
   private readonly apiKey: string;
 
   constructor({ baseUrl, organisationId, apiKey }: RequestSenderOptions) {
@@ -33,12 +33,19 @@ export class RequestSender {
         method,
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
+          ...(method !== 'GET'
+            ? {
+                'Content-Type': 'application/json',
+              }
+            : {}),
         },
-        body: JSON.stringify({
-          ...data,
-          organisationId: this.organisationId,
-        }),
+        body:
+          method !== 'GET'
+            ? JSON.stringify({
+                ...data,
+                organisationId: this.organisationId,
+              })
+            : null,
       });
 
       if (!response.ok) {

--- a/packages/sdk/src/resources/organisations/client.ts
+++ b/packages/sdk/src/resources/organisations/client.ts
@@ -1,0 +1,9 @@
+import { ElbaResourceClient } from '../elba-resource-client';
+import { type OrganisationsGetResult } from './types';
+
+export class OrganisationsClient extends ElbaResourceClient {
+  async list() {
+    const response = await this.requestSender.request('organisations', { method: 'GET' });
+    return response.json<OrganisationsGetResult>();
+  }
+}

--- a/packages/sdk/src/resources/organisations/types.ts
+++ b/packages/sdk/src/resources/organisations/types.ts
@@ -1,0 +1,8 @@
+export type Organisation = {
+  id: string;
+  nangoConnectionId: string | null;
+};
+
+export type OrganisationsGetResult = {
+  organisations: Organisation[];
+};

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,6 +1,6 @@
 export type ElbaOptions = {
-  organisationId: string;
+  organisationId?: string;
   apiKey: string;
   region: string;
-  baseUrl?: string;
+  baseUrl: string;
 };

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './redirection';
+export * from './regions';

--- a/packages/sdk/src/utils/regions.ts
+++ b/packages/sdk/src/utils/regions.ts
@@ -1,0 +1,1 @@
+export { elbaRegions, type ElbaRegion } from '@elba-security/schemas';

--- a/packages/test-utils/src/msw/request-handlers.ts
+++ b/packages/test-utils/src/msw/request-handlers.ts
@@ -2,6 +2,7 @@ import { type RequestHandler } from 'msw';
 import { createAuthRequestHandler } from './auth-request-handler';
 import { createConnectionStatusRequestHandlers } from './resources/connection-status';
 import { createDataProtectionRequestHandlers } from './resources/data-protection';
+import { createOrganisationsRequestHandlers } from './resources/organisations';
 import { createThirdPartyAppsRequestHandlers } from './resources/third-party-apps';
 import { createUsersRequestHandlers } from './resources/users';
 
@@ -10,5 +11,6 @@ export const createElbaRequestHandlers = (baseUrl: string, apiKey: string): Requ
   ...createConnectionStatusRequestHandlers(baseUrl),
   ...createDataProtectionRequestHandlers(baseUrl),
   ...createThirdPartyAppsRequestHandlers(baseUrl),
+  ...createOrganisationsRequestHandlers(baseUrl),
   ...createUsersRequestHandlers(baseUrl),
 ];

--- a/packages/test-utils/src/msw/resources/organisations.ts
+++ b/packages/test-utils/src/msw/resources/organisations.ts
@@ -1,0 +1,5 @@
+import { http, type RequestHandler } from 'msw';
+import { organisationsRoutes } from '@elba-security/api-client';
+
+export const createOrganisationsRequestHandlers = (baseUrl: string): RequestHandler[] =>
+  organisationsRoutes.map((route) => http[route.method](`${baseUrl}${route.path}`, route.handler));


### PR DESCRIPTION
## Description

This add new elba api endpoint to list organisations with active connections.
This endpoint returns the organisation id and the nango connection id when available.
Integrations could now rely on this endpoint on schedulers to directly fetch these organisations from the elba api instead of having a database to store them and retrieve them.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
