### PR TITLE
fix(linear): me id used to fetch the current auth user but it is not the case therefore viewer is used

### DIFF
--- a/apps/linear/src/connectors/linear/users.test.ts
+++ b/apps/linear/src/connectors/linear/users.test.ts
@@ -116,7 +116,7 @@ describe('users connector', () => {
 
           return Response.json({
             data: {
-              user: { id: authUserId },
+              viewer: { id: authUserId },
               organization: { urlKey: workspaceUrlKey },
             },
           });

--- a/apps/linear/src/connectors/linear/users.ts
+++ b/apps/linear/src/connectors/linear/users.ts
@@ -27,7 +27,7 @@ const linearResponseSchema = z.object({
 
 const authUserResponseSchema = z.object({
   data: z.object({
-    user: z.object({
+    viewer: z.object({
       id: z.string(),
     }),
     organization: z.object({
@@ -136,12 +136,12 @@ export const deleteUser = async ({ userId, accessToken }: DeleteUsersParams) => 
 export const getAuthUser = async (accessToken: string) => {
   const query = {
     query: `
-      query {
-        user(id: "me") {
-          id
-        }
+      query WhoAmIAndAndOrganisation {
         organization {
           urlKey
+        }
+        viewer {
+          id
         }
       }
     `,
@@ -170,7 +170,7 @@ export const getAuthUser = async (accessToken: string) => {
   }
 
   return {
-    authUserId: result.data.data.user.id,
+    authUserId: result.data.data.viewer.id,
     workspaceUrlKey: result.data.data.organization.urlKey,
   };
 };


### PR DESCRIPTION
## Description

We used  the following query to fetch the auth user 
`
query WhoAmI {
  user(id: "me") {
    id
  }
}
`
but it is not the case here, therefore the query is adjusted to this

`
query Me {
  viewer {
    id
  }
}
`

[Linear documentation to get the auth user.](https://developers.linear.app/docs/graphql/working-with-the-graphql-api#queries-mutations)



## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
