### PR TITLE
fix: fix failing deployment build by updating turbo config to add eve…

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "globalDependencies": ["**/.env.*local", "pnpm-workspace.yaml"],
   "tasks": {
     "build": {
+      "env": ["*"],
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },


### PR DESCRIPTION
## Description

This fixes vercel deployment where build was failing due to an update of turbo that enforce specifying env variables in the turbo config.
This updates the configuration to add every environment variables during build.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
