### PR TITLE
feat: add elba connection error inngest middleware

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -5,21 +5,27 @@
   "main": "src/index.ts",
   "scripts": {
     "lint": "eslint src/**.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@elba-security/logger": "workspace:*",
     "@elba-security/utils": "workspace:*",
     "@elba-security/schemas": "workspace:*",
     "@elba-security/sdk": "workspace:*",
-    "date-fns": "catalog:"
+    "date-fns": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@elba-security/eslint-config-custom": "workspace:*",
+    "@elba-security/test-utils": "workspace:*",
     "@elba-security/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "inngest": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "inngest": "catalog:"

--- a/packages/inngest/src/middlewares/elba-connection-error.test.ts
+++ b/packages/inngest/src/middlewares/elba-connection-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import { NonRetriableError } from 'inngest';
-import { createElbaConnectionErrorMiddelware } from './elba-connection-error';
+import { createElbaConnectionErrorMiddleware } from './elba-connection-error';
 
 const organisationId = '00000000-0000-0000-0000-000000000001';
 const region = 'us';
@@ -18,7 +18,7 @@ class UnauthorizedError extends Error {
   }
 }
 
-const middleware = createElbaConnectionErrorMiddelware({
+const middleware = createElbaConnectionErrorMiddleware({
   eventName: 'connection-error-event',
   mapErrorFn: (error) => {
     if (error instanceof UnauthorizedError) {

--- a/packages/inngest/src/middlewares/elba-connection-error.test.ts
+++ b/packages/inngest/src/middlewares/elba-connection-error.test.ts
@@ -1,25 +1,38 @@
-import { beforeEach } from 'node:test';
 import { describe, expect, test, vi } from 'vitest';
 import { NonRetriableError } from 'inngest';
-import { db } from '@/database/client';
-import { type Organisation, organisationsTable } from '@/database/schema';
-import { DocusignError } from '@/connectors/common/error';
-import { unauthorizedMiddleware } from './unauthorized-middleware';
+import { createElbaConnectionErrorMiddelware } from './elba-connection-error';
 
-const organisation: Omit<Organisation, 'createdAt'> = {
-  id: '00000000-0000-0000-0000-000000000001',
-  region: 'us',
-};
+const organisationId = '00000000-0000-0000-0000-000000000001';
+const region = 'us';
+
+class UnauthorizedError extends Error {
+  response: Response;
+
+  constructor(
+    message: string,
+    { response, ...opts }: Parameters<ErrorConstructor>[1] & { response: Response }
+  ) {
+    super(message, opts);
+    this.name = 'UnauthorizedError';
+    this.response = response;
+  }
+}
+
+const middleware = createElbaConnectionErrorMiddelware({
+  eventName: 'connection-error-event',
+  mapErrorFn: (error) => {
+    if (error instanceof UnauthorizedError) {
+      return 'unauthorized';
+    }
+    return null;
+  },
+});
 
 describe('unauthorized middleware', () => {
-  beforeEach(async () => {
-    await db.insert(organisationsTable).values(organisation);
-  });
-
   test('should not transform the output when their is no error', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     await expect(
-      unauthorizedMiddleware
+      middleware
         // @ts-expect-error -- this is a mock
         .init({ client: { send } })
         // @ts-expect-error -- this is a mock
@@ -32,10 +45,10 @@ describe('unauthorized middleware', () => {
     expect(send).toBeCalledTimes(0);
   });
 
-  test('should not transform the output when the error is not about Docusign authorization', async () => {
+  test('should not transform the output when the error is not mapped', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     await expect(
-      unauthorizedMiddleware
+      middleware
         // @ts-expect-error -- this is a mock
         .init({ client: { send } })
         // @ts-expect-error -- this is a mock
@@ -50,8 +63,8 @@ describe('unauthorized middleware', () => {
     expect(send).toBeCalledTimes(0);
   });
 
-  test('should transform the output error to NonRetriableError and remove the organisation when the error is about Docusign authorization', async () => {
-    const unauthorizedError = new DocusignError('foo bar', {
+  test('should transform the output error to NonRetriableError and send event when the error is mapped', async () => {
+    const unauthorizedError = new UnauthorizedError('foo bar', {
       // @ts-expect-error this is a mock
       response: {
         status: 401,
@@ -70,7 +83,7 @@ describe('unauthorized middleware', () => {
     };
 
     const send = vi.fn().mockResolvedValue(undefined);
-    const result = await unauthorizedMiddleware
+    const result = await middleware
       // @ts-expect-error -- this is a mock
       .init({ client: { send } })
       .onFunctionRun({
@@ -80,7 +93,8 @@ describe('unauthorized middleware', () => {
           // @ts-expect-error -- this is a mock
           event: {
             data: {
-              organisationId: organisation.id,
+              region,
+              organisationId,
             },
           },
         },
@@ -100,9 +114,19 @@ describe('unauthorized middleware', () => {
 
     expect(send).toBeCalledTimes(1);
     expect(send).toBeCalledWith({
-      name: 'docusign/app.uninstalled',
+      name: 'connection-error-event',
       data: {
-        organisationId: organisation.id,
+        region,
+        organisationId,
+        errorMetadata: {
+          message: 'foo bar',
+          name: 'UnauthorizedError',
+          response: {
+            status: 401,
+          },
+          stack: expect.any(String), // eslint-disable-line -- We can't exactly match the stack trace
+        },
+        errorType: 'unauthorized',
       },
     });
   });

--- a/packages/inngest/src/middlewares/elba-connection-error.ts
+++ b/packages/inngest/src/middlewares/elba-connection-error.ts
@@ -10,7 +10,7 @@ const requiredDataSchema = z.object({
 
 export type MapConnectionErrorFn = (error: unknown) => ConnectionErrorType | null;
 
-export const createElbaConnectionErrorMiddelware = ({
+export const createElbaConnectionErrorMiddleware = ({
   mapErrorFn,
   eventName,
 }: {

--- a/packages/inngest/src/middlewares/elba-connection-error.ts
+++ b/packages/inngest/src/middlewares/elba-connection-error.ts
@@ -1,19 +1,28 @@
+import { serializeLogObject } from '@elba-security/logger/src/serialize';
+import { elbaRegionSchema, type ConnectionErrorType } from '@elba-security/schemas';
 import { InngestMiddleware, NonRetriableError } from 'inngest';
-import { ElbaError } from '@elba-security/sdk';
 import { z } from 'zod';
-import { elbaRegionSchema } from '@elba-security/schemas';
 
 const requiredDataSchema = z.object({
   organisationId: z.string().uuid(),
-  region: elbaRegionSchema.optional(),
+  region: elbaRegionSchema,
 });
 
-export const createElbaTrialIssuesLimitExceededMiddleware = (cancelEventName: string) =>
-  new InngestMiddleware({
-    name: 'data-protection-api-middleware',
+export type MapConnectionErrorFn = (error: unknown) => ConnectionErrorType | null;
+
+export const createElbaConnectionErrorMiddelware = ({
+  mapErrorFn,
+  eventName,
+}: {
+  mapErrorFn: (error: unknown) => ConnectionErrorType | null;
+  eventName: string;
+}) => {
+  return new InngestMiddleware({
+    name: 'elba-connection-error',
     init: ({ client }) => {
       return {
         onFunctionRun: ({
+          fn,
           ctx: {
             event: { data },
           },
@@ -22,34 +31,34 @@ export const createElbaTrialIssuesLimitExceededMiddleware = (cancelEventName: st
             transformOutput: async (ctx) => {
               const {
                 result: { error, ...result },
+                ...context
               } = ctx;
-              if (!(error instanceof ElbaError) || !error.elbaApiErrors) {
-                return ctx;
-              }
 
-              const trialOrgIssuesLimitExceededError = error.elbaApiErrors.find(
-                ({ code }) => code === 'trial_org_issues_limit_exceeded'
-              );
-              if (!trialOrgIssuesLimitExceededError) {
-                return ctx;
+              const errorType = mapErrorFn(error);
+              if (!errorType) {
+                return;
               }
 
               const requiredDataResult = requiredDataSchema.safeParse(data);
               if (requiredDataResult.success) {
                 await client.send({
-                  name: cancelEventName,
+                  name: eventName,
                   data: {
                     organisationId: requiredDataResult.data.organisationId,
                     region: requiredDataResult.data.region,
+                    errorType,
+                    errorMetadata: serializeLogObject(error) as unknown,
                   },
                 });
               }
 
               return {
-                ...ctx,
+                ...context,
                 result: {
                   ...result,
-                  error: new NonRetriableError('Trial issues limit exceeded', { cause: error }),
+                  error: new NonRetriableError(`Detected '${errorType}' error in '${fn.name}'`, {
+                    cause: error,
+                  }),
                 },
               };
             },
@@ -58,3 +67,4 @@ export const createElbaTrialIssuesLimitExceededMiddleware = (cancelEventName: st
       };
     },
   });
+};

--- a/packages/inngest/src/middlewares/index.ts
+++ b/packages/inngest/src/middlewares/index.ts
@@ -1,2 +1,3 @@
 export * from './crypto';
 export * from './elba-trial-issues-limit';
+export * from './elba-connection-error';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3775,6 +3775,9 @@ importers:
 
   packages/inngest:
     dependencies:
+      '@elba-security/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@elba-security/schemas':
         specifier: workspace:*
         version: link:../schemas
@@ -3787,10 +3790,16 @@ importers:
       date-fns:
         specifier: 'catalog:'
         version: 3.6.0
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
     devDependencies:
       '@elba-security/eslint-config-custom':
         specifier: workspace:*
         version: link:../eslint-config-custom
+      '@elba-security/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@elba-security/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -3806,6 +3815,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.5.3
+      vitest:
+        specifier: 'catalog:'
+        version: 1.6.0(@edge-runtime/vm@3.2.0)(@types/node@20.14.2)
 
   packages/logger:
     devDependencies:


### PR DESCRIPTION
## Description

This adds an elba connection error inngest middleware.
The purpose of this middleware is to detect serious errors thrown during an inngest function execution. When the error is considered severe enough, it will abort the function executions and retries with an inngest NonRetriableError, and will send the desired event to trigger the inngest integration function to set an elba connection error.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
