### PR TITLE
chore(Google): batch delete permissions

### DIFF
--- a/apps/google/package.json
+++ b/apps/google/package.json
@@ -25,6 +25,7 @@
     "@elba-security/sdk": "workspace:*",
     "@googleapis/admin": "^15.0.0",
     "@googleapis/drive": "^8.7.0",
+    "@jrmdayn/googleapis-batcher": "^0.8.0",
     "@neondatabase/serverless": "catalog:",
     "@t3-oss/env-nextjs": "^0.7.1",
     "drizzle-orm": "catalog:",

--- a/apps/google/src/connectors/google/permissions.ts
+++ b/apps/google/src/connectors/google/permissions.ts
@@ -35,10 +35,14 @@ const googleFilePermissionFields = [
 const googleSharedDriveManagerPermissionFields = ['emailAddress', 'id', 'role', 'type'];
 
 export const deleteGooglePermission = async ({
+  fetchImplementation,
   supportsAllDrives = true,
   ...deletePermissionParams
-}: drive.Params$Resource$Permissions$Delete) => {
-  return new drive.Drive({}).permissions.delete({
+}: drive.Params$Resource$Permissions$Delete &
+  Pick<ConstructorParameters<typeof drive.Drive>[0], 'fetchImplementation'>) => {
+  return new drive.Drive({
+    fetchImplementation,
+  }).permissions.delete({
     ...deletePermissionParams,
     supportsAllDrives,
   });

--- a/apps/google/src/inngest/functions/data-protection/delete-object-permissions.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/delete-object-permissions.test.ts
@@ -21,6 +21,74 @@ describe('delete-data-protection-object-permissions', () => {
         const errors = {
           'permission-id-2': { code: 404, errors: [{ reason: 'notFound' }] },
           'permission-id-3': { code: 403, errors: [{ reason: 'insufficientFilePermissions' }] },
+        };
+        if (errors[permissionId as unknown as string]) {
+          return Promise.reject(errors[permissionId as unknown as string]); // eslint-disable-line @typescript-eslint/prefer-promise-reject-errors -- on purpose
+        }
+        return Promise.resolve(undefined);
+      }
+    );
+
+    await db.insert(organisationsTable).values({
+      googleAdminEmail: 'admin@org.local',
+      googleCustomerId: 'google-customer-id',
+      id: '00000000-0000-0000-0000-000000000000',
+      region: 'eu',
+    });
+    await db.insert(usersTable).values({
+      email: 'user@org.local',
+      id: 'user-id',
+      organisationId: '00000000-0000-0000-0000-000000000000',
+      lastSyncedAt: '2024-01-01T00:00:00Z',
+    });
+
+    const [result] = setup({
+      organisationId: '00000000-0000-0000-0000-000000000000',
+      objectId: 'object-id',
+      ownerId: 'user-id',
+      permissionIds: ['permission-id-1', 'permission-id-2', 'permission-id-3'],
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      deletedPermissions: ['permission-id-1'],
+      ignoredPermissions: ['permission-id-2', 'permission-id-3'],
+    });
+
+    expect(serviceAccountClientSpy).toBeCalledTimes(1);
+    expect(serviceAccountClientSpy).toBeCalledWith('user@org.local');
+
+    const authClient = serviceAccountClientSpy.mock.results[0]?.value as unknown;
+
+    expect(googlePermissions.deleteGooglePermission).toBeCalledTimes(3);
+    expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
+      auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
+      fileId: 'object-id',
+      permissionId: 'permission-id-1',
+    });
+    expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
+      auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
+      fileId: 'object-id',
+      permissionId: 'permission-id-2',
+    });
+    expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
+      auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
+      fileId: 'object-id',
+      permissionId: 'permission-id-3',
+    });
+  });
+
+  test('should throw an error if some permission deletion fail', async () => {
+    const serviceAccountClientSpy = spyOnGoogleServiceAccountClient();
+
+    vi.spyOn(googlePermissions, 'deleteGooglePermission').mockImplementation(
+      // @ts-expect-error -- this is a mock
+      ({ permissionId }) => {
+        const errors = {
+          'permission-id-2': { code: 404, errors: [{ reason: 'notFound' }] },
+          'permission-id-3': { code: 403, errors: [{ reason: 'insufficientFilePermissions' }] },
           'permission-id-4': { code: 500, errors: [{ reason: 'unknownError' }] },
         };
         if (errors[permissionId as unknown as string]) {
@@ -43,24 +111,16 @@ describe('delete-data-protection-object-permissions', () => {
       lastSyncedAt: '2024-01-01T00:00:00Z',
     });
 
-    const [result, { step }] = setup({
+    const [result] = setup({
       organisationId: '00000000-0000-0000-0000-000000000000',
       objectId: 'object-id',
       ownerId: 'user-id',
       permissionIds: ['permission-id-1', 'permission-id-2', 'permission-id-3', 'permission-id-4'],
     });
 
-    await expect(result).resolves.toStrictEqual({
-      deletedPermissions: ['permission-id-1'],
-      ignoredPermissions: ['permission-id-2', 'permission-id-3'],
-      unexpectedFailedPermissionIds: ['permission-id-4'],
-    });
-
-    expect(step.run).toBeCalledTimes(4);
-    expect(step.run).toBeCalledWith('delete-permission-permission-id-1', expect.any(Function));
-    expect(step.run).toBeCalledWith('delete-permission-permission-id-2', expect.any(Function));
-    expect(step.run).toBeCalledWith('delete-permission-permission-id-3', expect.any(Function));
-    expect(step.run).toBeCalledWith('delete-permission-permission-id-4', expect.any(Function));
+    await expect(result).rejects.toStrictEqual(
+      new Error('Unexpected errors occurred while revoking permissions')
+    );
 
     expect(serviceAccountClientSpy).toBeCalledTimes(1);
     expect(serviceAccountClientSpy).toBeCalledWith('user@org.local');
@@ -70,21 +130,25 @@ describe('delete-data-protection-object-permissions', () => {
     expect(googlePermissions.deleteGooglePermission).toBeCalledTimes(4);
     expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
       auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
       fileId: 'object-id',
       permissionId: 'permission-id-1',
     });
     expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
       auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
       fileId: 'object-id',
       permissionId: 'permission-id-2',
     });
     expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
       auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
       fileId: 'object-id',
       permissionId: 'permission-id-3',
     });
     expect(googlePermissions.deleteGooglePermission).toBeCalledWith({
       auth: authClient,
+      fetchImplementation: expect.any(Function), // eslint-disable-line -- convenience
       fileId: 'object-id',
       permissionId: 'permission-id-4',
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1616,6 +1616,9 @@ importers:
       '@googleapis/drive':
         specifier: ^8.7.0
         version: 8.7.0
+      '@jrmdayn/googleapis-batcher':
+        specifier: ^0.8.0
+        version: 0.8.0(gaxios@6.3.0)(googleapis@144.0.0)
       '@neondatabase/serverless':
         specifier: 'catalog:'
         version: 0.9.4
@@ -4705,6 +4708,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jrmdayn/googleapis-batcher@0.8.0':
+    resolution: {integrity: sha512-IMpBrpPZTw43jAX3HHAB4lOkUWBFZprntNYqYViUwEbmbszJIISoy+U0+CZfl75hJ1MZE4Dc8HAfal5S4GpLHA==}
+    peerDependencies:
+      gaxios: '>= 5'
+      googleapis: '>= 109'
+
   '@microsoft/microsoft-graph-types@2.40.0':
     resolution: {integrity: sha512-1fcPVrB/NkbNcGNfCy+Cgnvwxt6/sbIEEFgZHFBJ670zYLegENYJF8qMo7x3LqBjWX2/Eneq5BVVRCLTmlJN+g==}
 
@@ -5954,6 +5963,9 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
+
   date-fns-tz@3.2.0:
     resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
     peerDependencies:
@@ -6943,6 +6955,10 @@ packages:
     resolution: {integrity: sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==}
     engines: {node: '>=14.0.0'}
 
+  googleapis@144.0.0:
+    resolution: {integrity: sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==}
+    engines: {node: '>=14.0.0'}
+
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
@@ -6962,6 +6978,11 @@ packages:
 
   h3@1.9.0:
     resolution: {integrity: sha512-+F3ZqrNV/CFXXfZ2lXBINHi+rM4Xw3CDC5z2CDK3NMPocjonKipGLLDSkrqY9DOrioZNPTIdDMWfQKm//3X2DA==}
+
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
 
   hanji@0.0.5:
     resolution: {integrity: sha512-Abxw1Lq+TnYiL4BueXqMau222fPSPMFtya8HdpWsz/xVAhifXou71mPh/kY2+08RgFcVccjG3uZHs6K5HAe3zw==}
@@ -7707,6 +7728,12 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  next-line@1.1.0:
+    resolution: {integrity: sha512-+I10J3wKNoKddNxn0CNpoZ3eTZuqxjNM3b1GImVx22+ePI+Y15P8g/j3WsbP0fhzzrFzrtjOAoq5NCCucswXOQ==}
 
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
@@ -8885,6 +8912,11 @@ packages:
   ufo@1.3.2:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
@@ -9692,6 +9724,19 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.5.0
     optional: true
+
+  '@jrmdayn/googleapis-batcher@0.8.0(gaxios@6.3.0)(googleapis@144.0.0)':
+    dependencies:
+      dataloader: 2.2.3
+      debug: 4.3.7
+      gaxios: 6.3.0
+      googleapis: 144.0.0
+      handlebars: 4.7.8
+      next-line: 1.1.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@microsoft/microsoft-graph-types@2.40.0': {}
 
@@ -11203,6 +11248,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  dataloader@2.2.3: {}
+
   date-fns-tz@3.2.0(date-fns@3.6.0):
     dependencies:
       date-fns: 3.6.0
@@ -12415,6 +12462,14 @@ snapshots:
       - encoding
       - supports-color
 
+  googleapis@144.0.0:
+    dependencies:
+      google-auth-library: 9.6.3
+      googleapis-common: 7.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
@@ -12444,6 +12499,15 @@ snapshots:
       uncrypto: 0.1.3
       unenv: 1.8.0
     optional: true
+
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
 
   hanji@0.0.5:
     dependencies:
@@ -13194,6 +13258,10 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  neo-async@2.6.2: {}
+
+  next-line@1.1.0: {}
 
   next-tick@1.1.0: {}
 
@@ -14505,6 +14573,9 @@ snapshots:
   typescript@5.5.3: {}
 
   ufo@1.3.2: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   unbox-primitive@1.0.2:
     dependencies:


### PR DESCRIPTION
## Description

This use batch to delete Google permissions.
As the  official `googleapis` node library [doesn't support batch](https://github.com/googleapis/google-api-nodejs-client/issues/2375), 
 the package `@jrmdayn/googleapis-batcher` has been added, allowing batch request through the usage of `fetchImplementation` option provided by `googleapis`.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
