### PR TITLE
fix(onedrive): fix expired token while listing users during data protection sync

### DIFF
--- a/apps/onedrive/src/connectors/microsoft/delta/delta.test.ts
+++ b/apps/onedrive/src/connectors/microsoft/delta/delta.test.ts
@@ -7,6 +7,8 @@ import { type DeltaUser, getDeltaItems, type DeltaItem, getDeltaUsers } from './
 
 const userId = 'some-user-id';
 
+const tenantId = 'tenant-id';
+
 const validToken = 'token-1234';
 const nextDeltaToken = 'some-delta-token';
 
@@ -180,6 +182,7 @@ describe('delta connector', () => {
     test('should return delta users and nextSkipToken when there is another page', async () => {
       await expect(
         getDeltaUsers({
+          tenantId,
           token: validToken,
           skipToken: startSkipToken,
         })
@@ -192,6 +195,7 @@ describe('delta connector', () => {
     test('should return delta users and newDeltaToken when there is no next page', async () => {
       await expect(
         getDeltaUsers({
+          tenantId,
           token: validToken,
           skipToken: endSkipToken,
         })
@@ -204,6 +208,7 @@ describe('delta connector', () => {
     test('should throws when the token is invalid', async () => {
       await expect(
         getDeltaUsers({
+          tenantId,
           token: 'invalid-token',
           skipToken: endSkipToken,
         })

--- a/apps/onedrive/src/connectors/microsoft/delta/delta.test.ts
+++ b/apps/onedrive/src/connectors/microsoft/delta/delta.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, test, beforeEach } from 'vitest';
 import { server } from '@elba-security/test-utils';
 import { env } from '@/common/env';
 import { MicrosoftError } from '@/common/error';
-import { getDeltaItems, type DeltaItem } from './delta';
+import { type DeltaUser, getDeltaItems, type DeltaItem, getDeltaUsers } from './delta';
 
 const userId = 'some-user-id';
 
 const validToken = 'token-1234';
-const deltaToken = 'some-delta-token';
+const nextDeltaToken = 'some-delta-token';
 
 const startSkipToken = 'start-skip-token';
 const endSkipToken = 'end-skip-token';
@@ -28,6 +28,15 @@ const deltaItems: DeltaItem[] = Array.from({ length: 2 }, (_, i) => ({
     id: `some-parent-id-1`,
   },
   ...(i === 0 ? { deleted: { state: 'deleted' } } : {}),
+}));
+
+const deltaUsers: DeltaUser[] = Array.from({ length: 2 }, (_, i) => ({
+  id: `user-id-${i}`,
+  ...(i === 0
+    ? { '@removed': { reason: 'changed' } }
+    : {
+        userType: 'Member',
+      }),
 }));
 
 describe('delta connector', () => {
@@ -52,16 +61,16 @@ describe('delta connector', () => {
 
             const selectedKeys = select?.split(',') || ([] as unknown as (keyof DeltaItem)[]);
 
-            const formattedDelta = deltaItems.map((site) =>
+            const formattedDelta = deltaItems.map((item) =>
               selectedKeys.reduce<Partial<DeltaItem>>((acc, key: keyof DeltaItem) => {
-                return { ...acc, [key]: site[key] };
+                return { ...acc, [key]: item[key] };
               }, {})
             );
 
-            const nextPageUrl = new URL(url);
+            const nextPageUrl = new URL(`${env.MICROSOFT_API_URL}/users/:userId/drive/root/delta`);
             nextPageUrl.searchParams.set(
               'token',
-              token === endSkipToken ? deltaToken : nextSkipToken
+              token === endSkipToken ? nextDeltaToken : nextSkipToken
             );
 
             const addToken =
@@ -100,7 +109,7 @@ describe('delta connector', () => {
         })
       ).resolves.toStrictEqual({
         items: { deleted: [deltaItems[0]?.id], updated: [deltaItems[1]] },
-        newDeltaToken: deltaToken,
+        newDeltaToken: nextDeltaToken,
       });
     });
 
@@ -122,6 +131,83 @@ describe('delta connector', () => {
           deltaToken: null,
         })
       ).resolves.toBeNull();
+    });
+  });
+
+  describe('getDeltaUsers', () => {
+    // mock token API endpoint using msw
+    beforeEach(() => {
+      server.use(
+        http.get(`${env.MICROSOFT_API_URL}/:tenantId/users/delta`, ({ request }) => {
+          if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+            return new Response(undefined, { status: 401 });
+          }
+
+          const url = new URL(request.url);
+          const select = url.searchParams.get('$select');
+          const skipToken = url.searchParams.get('$skiptoken');
+
+          const selectedKeys = select?.split(',') || ([] as unknown as (keyof DeltaUser)[]);
+
+          const formattedDelta = deltaUsers.map((user) =>
+            selectedKeys.reduce<Partial<DeltaUser>>((acc, key: keyof DeltaUser) => {
+              return { ...acc, [key]: user[key], '@removed': user['@removed'] };
+            }, {})
+          );
+
+          const nextPageUrl = new URL(`${env.MICROSOFT_API_URL}/users/delta`);
+          nextPageUrl.searchParams.delete('$deltatoken');
+          nextPageUrl.searchParams.delete('$skiptoken');
+          if (skipToken === endSkipToken) {
+            nextPageUrl.searchParams.set('$deltatoken', nextDeltaToken);
+          } else {
+            nextPageUrl.searchParams.set('$skiptoken', nextSkipToken);
+          }
+
+          const addToken =
+            skipToken === endSkipToken
+              ? { '@odata.deltaLink': decodeURIComponent(nextPageUrl.toString()) }
+              : { '@odata.nextLink': decodeURIComponent(nextPageUrl.toString()) };
+
+          return Response.json({
+            value: formattedDelta,
+            ...addToken,
+          });
+        })
+      );
+    });
+
+    test('should return delta users and nextSkipToken when there is another page', async () => {
+      await expect(
+        getDeltaUsers({
+          token: validToken,
+          skipToken: startSkipToken,
+        })
+      ).resolves.toStrictEqual({
+        users: { deleted: [deltaUsers[0]?.id], updated: [deltaUsers[1]] },
+        nextSkipToken,
+      });
+    });
+
+    test('should return delta users and newDeltaToken when there is no next page', async () => {
+      await expect(
+        getDeltaUsers({
+          token: validToken,
+          skipToken: endSkipToken,
+        })
+      ).resolves.toStrictEqual({
+        users: { deleted: [deltaUsers[0]?.id], updated: [deltaUsers[1]] },
+        newDeltaToken: nextDeltaToken,
+      });
+    });
+
+    test('should throws when the token is invalid', async () => {
+      await expect(
+        getDeltaUsers({
+          token: 'invalid-token',
+          skipToken: endSkipToken,
+        })
+      ).rejects.toBeInstanceOf(MicrosoftError);
     });
   });
 });

--- a/apps/onedrive/src/connectors/microsoft/users/users.test.ts
+++ b/apps/onedrive/src/connectors/microsoft/users/users.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, beforeEach } from 'vitest';
 import { server } from '@elba-security/test-utils';
 import { env } from '@/common/env';
 import { MicrosoftError } from '@/common/error';
-import { getOrganisationUserIds, getUsers } from './users';
+import { getUsers } from './users';
 import type { MicrosoftUser } from './users';
 
 const validToken = 'token-1234';
@@ -31,8 +31,6 @@ const validUsers: (MicrosoftUser & { userType: string })[] = Array.from(
     displayName: `user ${i}`,
   })
 );
-
-const userIds = validUsers.filter((user) => user.userType === 'Member').map(({ id }) => id);
 
 const users = [...validUsers, ...invalidUsers];
 
@@ -115,42 +113,6 @@ describe('auth connector', () => {
     test('should throws when the tenantId is invalid', async () => {
       await expect(
         getUsers({ tenantId: 'invalid-tenant-id', token: validToken, skipToken: endSkipToken })
-      ).rejects.toBeInstanceOf(MicrosoftError);
-    });
-  });
-
-  describe('getOrganisationUserIds', () => {
-    test('should return userIds and nextSkipToken when the token is valid and there is another page', async () => {
-      await expect(
-        getOrganisationUserIds({ tenantId, token: validToken, skipToken: startSkipToken })
-      ).resolves.toStrictEqual({
-        userIds,
-        nextSkipToken,
-      });
-    });
-
-    test('should return userIds and no nextSkipToken when the token is valid and there is no other page', async () => {
-      await expect(
-        getOrganisationUserIds({ tenantId, token: validToken, skipToken: endSkipToken })
-      ).resolves.toStrictEqual({
-        userIds,
-        nextSkipToken: null,
-      });
-    });
-
-    test('should throws when the token is invalid', async () => {
-      await expect(
-        getOrganisationUserIds({ tenantId, token: 'invalid-token', skipToken: endSkipToken })
-      ).rejects.toBeInstanceOf(MicrosoftError);
-    });
-
-    test('should throws when the tenantId is invalid', async () => {
-      await expect(
-        getOrganisationUserIds({
-          tenantId: 'invalid-tenant-id',
-          token: validToken,
-          skipToken: endSkipToken,
-        })
       ).rejects.toBeInstanceOf(MicrosoftError);
     });
   });

--- a/apps/onedrive/src/connectors/microsoft/users/users.ts
+++ b/apps/onedrive/src/connectors/microsoft/users/users.ts
@@ -11,10 +11,6 @@ const userSchema = z.object({
   displayName: z.string().nullable().optional(),
 });
 
-const organisationUserSchema = z.object({
-  id: z.string(),
-});
-
 export type MicrosoftUser = z.infer<typeof userSchema>;
 
 export type GetUsersParams = {
@@ -64,46 +60,4 @@ export const getUsers = async ({ token, tenantId, skipToken }: GetUsersParams) =
   const nextSkipToken = result.data['@odata.nextLink'];
 
   return { validUsers, invalidUsers, nextSkipToken };
-};
-
-export const getOrganisationUserIds = async ({ token, tenantId, skipToken }: GetUsersParams) => {
-  const url = new URL(`${env.MICROSOFT_API_URL}/${tenantId}/users`);
-  url.searchParams.append('$top', String(env.USERS_SYNC_BATCH_SIZE));
-  url.searchParams.append('$select', Object.keys(organisationUserSchema.shape).join(','));
-  url.searchParams.append('$filter', "userType eq 'Member'");
-
-  if (skipToken) {
-    url.searchParams.append('$skiptoken', skipToken);
-  }
-
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new MicrosoftError('Could not retrieve organisation users', { response });
-  }
-
-  const data: unknown = await response.json();
-  const result = microsoftPaginatedResponseSchema.safeParse(data);
-  if (!result.success) {
-    logger.error('Failed to parse users', { data, error: result.error });
-    throw new Error('Could not parse users');
-  }
-
-  const userIds: string[] = [];
-  for (const user of result.data.value) {
-    const parsedUser = organisationUserSchema.safeParse(user);
-    if (!parsedUser.success) {
-      logger.error('Failed to parse user', { user, error: parsedUser.error });
-    } else {
-      userIds.push(parsedUser.data.id);
-    }
-  }
-
-  const nextSkipToken = result.data['@odata.nextLink'];
-
-  return { userIds, nextSkipToken };
 };


### PR DESCRIPTION
## Description

This fixes a bug where the `skipToken` provided by microsoft when listing users during data protection sync could expire if the sync was taking few hours for a single users page.
To fix this, instead of relying of the traditional endpoint to list users, we now rely on the delta users endpoint, where the token should in theory not expire.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
