### PR TITLE
fix(calendly): check admin role during installation validation

### DIFF
--- a/apps/calendly/src/connectors/calendly/users.ts
+++ b/apps/calendly/src/connectors/calendly/users.ts
@@ -25,6 +25,7 @@ export type GetUsersParams = {
   accessToken: string;
   organizationUri: string;
   page?: string | null;
+  userUri?: string;
 };
 
 export type DeleteUsersParams = {
@@ -32,7 +33,7 @@ export type DeleteUsersParams = {
   userId: string;
 };
 
-export const getUsers = async ({ accessToken, organizationUri, page }: GetUsersParams) => {
+export const getUsers = async ({ accessToken, organizationUri, page, userUri }: GetUsersParams) => {
   const url = new URL(`${env.CALENDLY_API_BASE_URL}/organization_memberships`);
 
   url.searchParams.append('organization', organizationUri);
@@ -40,6 +41,10 @@ export const getUsers = async ({ accessToken, organizationUri, page }: GetUsersP
 
   if (page) {
     url.searchParams.append('page_token', page);
+  }
+
+  if (userUri) {
+    url.searchParams.append('user', userUri);
   }
 
   const response = await fetch(url.toString(), {

--- a/apps/calendly/src/connectors/common/error.ts
+++ b/apps/calendly/src/connectors/common/error.ts
@@ -15,13 +15,21 @@ export class CalendlyError extends Error {
 
 export class CalendlyUnsupportedPlanError extends CalendlyError {}
 
+export class CalendlyNotAdminError extends CalendlyError {}
+
 export const mapElbaConnectionError: MapConnectionErrorFn = (error) => {
   if (error instanceof NangoConnectionError && error.response.status === 404) {
     return 'unauthorized';
   }
-  if (error instanceof CalendlyError && error.response?.status !== 401) {
+
+  if (error instanceof CalendlyError && error.response?.status === 401) {
     return 'unauthorized';
   }
+
+  if (error instanceof CalendlyNotAdminError) {
+    return 'not_admin';
+  }
+
   if (error instanceof CalendlyUnsupportedPlanError) {
     return 'unsupported_plan';
   }

--- a/apps/docusign/src/connectors/common/error.ts
+++ b/apps/docusign/src/connectors/common/error.ts
@@ -19,7 +19,7 @@ export const mapElbaConnectionError: MapConnectionErrorFn = (error) => {
   if (error instanceof NangoConnectionError && error.response.status === 404) {
     return 'unauthorized';
   }
-  if (error instanceof DocusignError && error.response?.status !== 401) {
+  if (error instanceof DocusignError && error.response?.status === 401) {
     return 'unauthorized';
   }
   if (error instanceof DocusignNotAdminError) {


### PR DESCRIPTION
## Description

Check if user is admin during Calendly installation validation

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
