### PR TITLE
chore: include new error code multiple_workspaces_not_supported

### DIFF
--- a/packages/schemas/src/connection-status.ts
+++ b/packages/schemas/src/connection-status.ts
@@ -7,6 +7,7 @@ export const connectionErrorTypeSchema = z.enum([
   'unauthorized',
   'unknown',
   'unsupported_plan',
+  'multiple_workspaces_not_supported',
 ]);
 
 export type ConnectionErrorType = zInfer<typeof connectionErrorTypeSchema>;


### PR DESCRIPTION
## Description

in general we don't support multiple workspaces, therefore we should stop selecting multiple workspaces after login.   for example for Clickup allows to select  multiple workspaces after login, but we don't support multi workspaces at this time.
## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
