### PR TITLE
fix: organisation connection error

### DIFF
--- a/apps/onedrive/src/inngest/functions/subscriptions/remove-subscription.ts
+++ b/apps/onedrive/src/inngest/functions/subscriptions/remove-subscription.ts
@@ -11,15 +11,19 @@ export const removeSubscription = inngest.createFunction(
     id: 'onedrive-remove-subscription',
     cancelOn: [
       {
-        event: 'onedrive/app.uninstalled',
-        match: 'data.organisationId',
-      },
-      {
         event: 'onedrive/app.installed',
         match: 'data.organisationId',
       },
     ],
     retries: 5,
+    onFailure: async ({ event, step }) => {
+      const { organisationId, subscriptionId } = event.data.event.data;
+
+      await step.sendEvent('subscription-removal-failed', {
+        name: 'onedrive/subscriptions.remove.completed',
+        data: { organisationId, subscriptionId },
+      });
+    },
   },
   { event: 'onedrive/subscriptions.remove.triggered' },
   async ({ event, step }) => {

--- a/apps/sharepoint/src/inngest/functions/subscriptions/remove-subscription.ts
+++ b/apps/sharepoint/src/inngest/functions/subscriptions/remove-subscription.ts
@@ -11,15 +11,19 @@ export const removeSubscription = inngest.createFunction(
     id: 'sharepoint-remove-subscription',
     cancelOn: [
       {
-        event: 'sharepoint/app.uninstalled',
-        match: 'data.organisationId',
-      },
-      {
         event: 'sharepoint/app.installed',
         match: 'data.organisationId',
       },
     ],
     retries: 5,
+    onFailure: async ({ event, step }) => {
+      const { organisationId, subscriptionId } = event.data.event.data;
+
+      await step.sendEvent('subscription-removal-failed', {
+        name: 'sharepoint/subscriptions.remove.completed',
+        data: { organisationId, subscriptionId },
+      });
+    },
   },
   { event: 'sharepoint/subscriptions.remove.triggered' },
   async ({ event, step }) => {

--- a/apps/teams/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/teams/src/inngest/functions/organisations/remove-organisation.ts
@@ -37,7 +37,7 @@ export const removeOrganisation = inngest.createFunction(
       .where(eq(subscriptionsTable.organisationId, organisationId));
 
     if (subscriptions.length) {
-      await Promise.all(
+      await Promise.allSettled(
         subscriptions.map((subscription) =>
           deleteSubscription(organisation.token, subscription.subscriptionId)
         )


### PR DESCRIPTION
## Description

This fixes a bug for some Microsoft integration that were trying to remove subscription during organisation removal. These subscriptions removal could fail which would result in not properly removing the organisation and setting its connection error

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
