### PR TITLE
fix: microsoft integrations

### DIFF
--- a/apps/microsoft/src/inngest/functions/token/refresh-token.ts
+++ b/apps/microsoft/src/inngest/functions/token/refresh-token.ts
@@ -6,6 +6,7 @@ import { inngest } from '@/inngest/client';
 import { getToken } from '@/connectors/microsoft/auth';
 import { env } from '@/env';
 import { encrypt } from '@/common/crypto';
+import { unauthorizedMiddleware } from '@/inngest/middlewares/unauthorized-middleware';
 
 export const refreshToken = inngest.createFunction(
   {
@@ -25,8 +26,7 @@ export const refreshToken = inngest.createFunction(
       },
     ],
     retries: env.TOKEN_REFRESH_MAX_RETRY,
-    // TODO: improve 401 filtering before re-applying
-    // middleware: [unauthorizedMiddleware],
+    middleware: [unauthorizedMiddleware],
   },
   { event: 'microsoft/token.refresh.requested' },
   async ({ event }) => {

--- a/apps/onedrive/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/onedrive/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -47,19 +47,29 @@ describe('remove-organisation', () => {
 
     expect(step.waitForEvent).toBeCalledTimes(oneDrives.length);
 
-    for (let i = 0; i < oneDrives.length; i++) {
-      const oneDrive = oneDrives[i];
-
+    for (const [i, subscription] of oneDrives.entries()) {
       expect(step.waitForEvent).nthCalledWith(
         i + 1,
-        `wait-for-remove-subscription-complete-${oneDrive?.subscriptionId}`,
+        `wait-for-remove-subscription-complete-${subscription.subscriptionId}`,
         {
           event: 'onedrive/subscriptions.remove.completed',
           timeout: '30d',
-          if: `async.data.organisationId == '${oneDrive?.organisationId}' && async.data.subscriptionId == '${oneDrive?.subscriptionId}'`,
+          if: `async.data.organisationId == '${subscription.organisationId}' && async.data.subscriptionId == '${subscription.subscriptionId}'`,
         }
       );
     }
+
+    expect(step.sendEvent).toHaveBeenCalledTimes(1);
+    expect(step.sendEvent).toHaveBeenCalledWith(
+      'subscription-remove-triggered',
+      oneDrives.map(({ organisationId, subscriptionId }) => ({
+        name: 'onedrive/subscriptions.remove.triggered',
+        data: {
+          organisationId,
+          subscriptionId,
+        },
+      }))
+    );
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({

--- a/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -48,19 +48,29 @@ describe('remove-organisation', () => {
 
     expect(step.waitForEvent).toBeCalledTimes(sharePoints.length);
 
-    for (let i = 0; i < sharePoints.length; i++) {
-      const sharePoint = sharePoints[i];
-
+    for (const [i, subscription] of sharePoints.entries()) {
       expect(step.waitForEvent).nthCalledWith(
         i + 1,
-        `wait-for-remove-subscription-complete-${sharePoint?.subscriptionId}`,
+        `wait-for-remove-subscription-complete-${subscription.subscriptionId}`,
         {
           event: 'sharepoint/subscriptions.remove.completed',
           timeout: '30d',
-          if: `async.data.organisationId == '${sharePoint?.organisationId}' && async.data.subscriptionId == '${sharePoint?.subscriptionId}'`,
+          if: `async.data.organisationId == '${subscription.organisationId}' && async.data.subscriptionId == '${subscription.subscriptionId}'`,
         }
       );
     }
+
+    expect(step.sendEvent).toHaveBeenCalledTimes(1);
+    expect(step.sendEvent).toHaveBeenCalledWith(
+      'subscription-remove-triggered',
+      sharePoints.map(({ organisationId, subscriptionId }) => ({
+        name: 'sharepoint/subscriptions.remove.triggered',
+        data: {
+          organisationId,
+          subscriptionId,
+        },
+      }))
+    );
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({

--- a/apps/teams/src/inngest/client.ts
+++ b/apps/teams/src/inngest/client.ts
@@ -137,6 +137,18 @@ export const inngest = new Inngest({
         organisationId: string;
       };
     };
+    'teams/subscriptions.remove.triggered': {
+      data: {
+        subscriptionId: string;
+        organisationId: string;
+      };
+    };
+    'teams/subscriptions.remove.completed': {
+      data: {
+        subscriptionId: string;
+        organisationId: string;
+      };
+    };
   }>(),
   middleware: [
     rateLimitMiddleware,

--- a/apps/teams/src/inngest/functions/channels/index.ts
+++ b/apps/teams/src/inngest/functions/channels/index.ts
@@ -1,8 +1,8 @@
-import { scheduleTeamsSync } from '@/inngest/functions/channels/schedule-teams-sync';
-import { syncTeams } from '@/inngest/functions/channels/sync-teams';
-import { syncChannels } from '@/inngest/functions/channels/sync-channels';
-import { syncMessages } from '@/inngest/functions/channels/sync-messages';
-import { syncReplies } from '@/inngest/functions/channels/sync-replies';
+import { scheduleTeamsSync } from './schedule-teams-sync';
+import { syncTeams } from './sync-teams';
+import { syncChannels } from './sync-channels';
+import { syncMessages } from './sync-messages';
+import { syncReplies } from './sync-replies';
 
 export const channelsFunctions = [
   scheduleTeamsSync,

--- a/apps/teams/src/inngest/functions/data-protection/index.ts
+++ b/apps/teams/src/inngest/functions/data-protection/index.ts
@@ -1,3 +1,3 @@
-import { refreshDataProtectionObject } from '@/inngest/functions/data-protection/refresh-data-protection-object';
+import { refreshDataProtectionObject } from './refresh-data-protection-object';
 
 export const dataProtectionFunctions = [refreshDataProtectionObject];

--- a/apps/teams/src/inngest/functions/organisations/index.ts
+++ b/apps/teams/src/inngest/functions/organisations/index.ts
@@ -1,3 +1,3 @@
-import { removeOrganisation } from '@/inngest/functions/organisations/remove-organisation';
+import { removeOrganisation } from './remove-organisation';
 
 export const organisationsFunctions = [removeOrganisation];

--- a/apps/teams/src/inngest/functions/subscriptions/index.ts
+++ b/apps/teams/src/inngest/functions/subscriptions/index.ts
@@ -1,13 +1,15 @@
-import { createSubscriptionToChannels } from '@/inngest/functions/subscriptions/create-subscription-to-channels';
-import { createSubscriptionToChannelMessages } from '@/inngest/functions/subscriptions/create-subscription-to-channel-messages';
-import { refreshSubscription } from '@/inngest/functions/subscriptions/refresh-subscription';
-import { startRecreateSubscriptionsForOrganisations } from '@/inngest/functions/subscriptions/start-recreate-subscriptions-for-organisations';
-import { recreateSubscriptionsForOrganisation } from '@/inngest/functions/subscriptions/recreate-subscriptions-for-organisation';
+import { createSubscriptionToChannels } from './create-subscription-to-channels';
+import { createSubscriptionToChannelMessages } from './create-subscription-to-channel-messages';
+import { refreshSubscription } from './refresh-subscription';
+import { startRecreateSubscriptionsForOrganisations } from './start-recreate-subscriptions-for-organisations';
+import { recreateSubscriptionsForOrganisation } from './recreate-subscriptions-for-organisation';
+import { removeSubscription } from './remove-subscription';
 
 export const subscriptionsFunctions = [
-  createSubscriptionToChannels,
   createSubscriptionToChannelMessages,
-  refreshSubscription,
-  startRecreateSubscriptionsForOrganisations,
+  createSubscriptionToChannels,
   recreateSubscriptionsForOrganisation,
+  refreshSubscription,
+  removeSubscription,
+  startRecreateSubscriptionsForOrganisations,
 ];

--- a/apps/teams/src/inngest/functions/subscriptions/remove-subscription.test.ts
+++ b/apps/teams/src/inngest/functions/subscriptions/remove-subscription.test.ts
@@ -1,0 +1,93 @@
+import { expect, test, describe, vi, beforeEach } from 'vitest';
+import { createInngestFunctionMock } from '@elba-security/test-utils';
+import { NonRetriableError } from 'inngest';
+import * as removeSubscriptionConnector from '@/connectors/microsoft/subscriptions/subscriptions';
+import { organisationsTable, subscriptionsTable } from '@/database/schema';
+import { encrypt } from '@/common/crypto';
+import { db } from '@/database/client';
+import { removeSubscription } from './remove-subscription';
+
+const token = 'test-token';
+const organisationId = '45a76301-f1dd-4a77-b12f-9d7d3fca3c90';
+const subscriptionId = 'some-subscription-id';
+const tenantId = 'some-tenant-id';
+const resource = 'some-resource';
+const changeType = 'some-change-type';
+
+const encryptedToken = await encrypt(token);
+
+const organisation = {
+  id: organisationId,
+  token: encryptedToken,
+  tenantId,
+  region: 'us',
+};
+
+const subscription = {
+  organisationId,
+  id: subscriptionId,
+  resource,
+  changeType,
+};
+
+const setupData = {
+  subscriptionId: subscription.id,
+  organisationId: organisation.id,
+};
+
+const setup = createInngestFunctionMock(removeSubscription, 'teams/subscriptions.remove.triggered');
+
+describe('remove-subscription', () => {
+  beforeEach(async () => {
+    await db.insert(organisationsTable).values(organisation);
+    await db
+      .insert(subscriptionsTable)
+      .values(subscription)
+      .onConflictDoUpdate({
+        target: [subscriptionsTable.id],
+
+        set: {
+          organisationId: subscription.organisationId,
+          changeType: subscription.changeType,
+          resource: subscription.resource,
+        },
+      });
+  });
+
+  test('should abort removing when record not found', async () => {
+    vi.spyOn(removeSubscriptionConnector, 'deleteSubscription').mockResolvedValue(null);
+
+    const [result, { step }] = setup({
+      ...setupData,
+      organisationId: '15a76301-f1dd-4a77-b12a-9d7d3fca3c92', // fake id
+    });
+
+    await expect(result).rejects.toBeInstanceOf(NonRetriableError);
+
+    expect(removeSubscriptionConnector.deleteSubscription).toBeCalledTimes(0);
+    expect(step.sendEvent).toBeCalledTimes(0);
+  });
+
+  test('should run removeSubscription when data is valid', async () => {
+    vi.spyOn(removeSubscriptionConnector, 'deleteSubscription').mockResolvedValue(null);
+
+    const [result, { step }] = setup(setupData);
+
+    await expect(result).resolves.toBeUndefined();
+
+    expect(removeSubscriptionConnector.deleteSubscription).toBeCalledTimes(1);
+    expect(removeSubscriptionConnector.deleteSubscription).toBeCalledWith(
+      encryptedToken,
+      subscriptionId
+    );
+
+    expect(step.sendEvent).toBeCalledTimes(1);
+    expect(step.sendEvent).toBeCalledWith('remove-subscription-completed', {
+      name: 'teams/subscriptions.remove.completed',
+      data: {
+        subscriptionId,
+        organisationId,
+      },
+    });
+  });
+});

--- a/apps/teams/src/inngest/functions/subscriptions/remove-subscription.ts
+++ b/apps/teams/src/inngest/functions/subscriptions/remove-subscription.ts
@@ -1,0 +1,60 @@
+import { and, eq } from 'drizzle-orm';
+import { NonRetriableError } from 'inngest';
+import { inngest } from '@/inngest/client';
+import { db } from '@/database/client';
+import { organisationsTable, subscriptionsTable } from '@/database/schema';
+import { deleteSubscription } from '@/connectors/microsoft/subscriptions/subscriptions';
+
+export const removeSubscription = inngest.createFunction(
+  {
+    id: 'teams-remove-subscription',
+    cancelOn: [
+      {
+        event: 'teams/app.installed',
+        match: 'data.organisationId',
+      },
+    ],
+    retries: 5,
+    onFailure: async ({ event, step }) => {
+      const { organisationId, subscriptionId } = event.data.event.data;
+
+      await step.sendEvent('subscription-removal-failed', {
+        name: 'teams/subscriptions.remove.completed',
+        data: { organisationId, subscriptionId },
+      });
+    },
+  },
+  { event: 'teams/subscriptions.remove.triggered' },
+  async ({ event, step }) => {
+    const { subscriptionId, organisationId } = event.data;
+
+    const [record] = await db
+      .select({
+        token: organisationsTable.token,
+      })
+      .from(subscriptionsTable)
+      .innerJoin(organisationsTable, eq(subscriptionsTable.organisationId, organisationsTable.id))
+      .where(
+        and(
+          eq(subscriptionsTable.organisationId, organisationId),
+          eq(subscriptionsTable.id, subscriptionId)
+        )
+      );
+
+    if (!record) {
+      throw new NonRetriableError(
+        `Could not retrieve organisation with organisationId=${organisationId} and subscriptionId=${subscriptionId}`
+      );
+    }
+
+    await deleteSubscription(record.token, subscriptionId);
+
+    await step.sendEvent('remove-subscription-completed', {
+      name: 'teams/subscriptions.remove.completed',
+      data: {
+        subscriptionId,
+        organisationId,
+      },
+    });
+  }
+);

--- a/apps/teams/src/inngest/functions/teams/event-handlers/index.ts
+++ b/apps/teams/src/inngest/functions/teams/event-handlers/index.ts
@@ -1,12 +1,12 @@
-import { channelCreatedHandler } from '@/inngest/functions/teams/event-handlers/channel-created';
 import type { TeamsWebhookHandlerContext } from '@/inngest/functions/teams/handle-team-webhook-event';
-import { channelDeletedHandler } from '@/inngest/functions/teams/event-handlers/channel-deleted';
 import type { WebhookPayload } from '@/app/api/webhooks/microsoft/event-handler/service';
 import { EventType } from '@/app/api/webhooks/microsoft/event-handler/service';
-import { messageCreatedOrUpdatedHandler } from '@/inngest/functions/teams/event-handlers/message-created-updated';
-import { replyCreatedOrUpdatedHandler } from '@/inngest/functions/teams/event-handlers/reply-created-updated';
-import { messageDeletedHandler } from '@/inngest/functions/teams/event-handlers/message-deleted';
-import { replyDeletedHandler } from '@/inngest/functions/teams/event-handlers/reply-deleted';
+import { channelDeletedHandler } from './channel-deleted';
+import { channelCreatedHandler } from './channel-created';
+import { messageCreatedOrUpdatedHandler } from './message-created-updated';
+import { replyCreatedOrUpdatedHandler } from './reply-created-updated';
+import { messageDeletedHandler } from './message-deleted';
+import { replyDeletedHandler } from './reply-deleted';
 
 export type TeamsEventHandler = (
   event: WebhookPayload,

--- a/apps/teams/src/inngest/functions/teams/index.ts
+++ b/apps/teams/src/inngest/functions/teams/index.ts
@@ -1,3 +1,3 @@
-import { handleTeamsWebhookEvent } from '@/inngest/functions/teams/handle-team-webhook-event';
+import { handleTeamsWebhookEvent } from './handle-team-webhook-event';
 
 export const teamsFunctions = [handleTeamsWebhookEvent];

--- a/apps/teams/src/inngest/functions/tokens/index.ts
+++ b/apps/teams/src/inngest/functions/tokens/index.ts
@@ -1,4 +1,4 @@
-import { refreshToken } from '@/inngest/functions/tokens/refresh-token';
+import { refreshToken } from './refresh-token';
 import { scheduleTokenRefresh } from './schedule-token-refresh';
 
 export const tokenFunctions = [refreshToken, scheduleTokenRefresh];


### PR DESCRIPTION
## Description

This fixes Microsoft integrations.
Changes:
- Microsoft integration: remove organisation properly when facing unauthorized error during token refresh
- Teams integration: fix organisation removal that was trying to remove every organisation subscription which could lead to too many requests. This has been fixed by having a dedicated inngest function to remove a subscription like on OneDrive & SharePoint integrations.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
