### PR TITLE
fix: microsoft subscription removal

### DIFF
--- a/apps/onedrive/src/common/env.ts
+++ b/apps/onedrive/src/common/env.ts
@@ -42,6 +42,7 @@ export const env = z
       .default('https://login.microsoftonline.com/organizations/adminconsent'),
     MICROSOFT_REDIRECT_URI: z.string().url(),
     SUBSCRIPTION_EXPIRATION_DAYS: z.string().default('25'),
+    SUBSCRIPTION_REMOVAL_BATCH_SIZE: zEnvInt().default(100),
     TOKEN_REFRESH_CRON: z.string().default('*/30 * * * *'),
     USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
     USERS_SYNC_CRON: z.string().default('0 0 * * 1-5'),

--- a/apps/onedrive/src/inngest/client.ts
+++ b/apps/onedrive/src/inngest/client.ts
@@ -93,13 +93,11 @@ export const inngest = new Inngest({
     };
     'onedrive/subscriptions.remove.triggered': {
       data: {
-        subscriptionId: string;
         organisationId: string;
       };
     };
     'onedrive/subscriptions.remove.completed': {
       data: {
-        subscriptionId: string;
         organisationId: string;
       };
     };

--- a/apps/onedrive/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/onedrive/src/inngest/functions/organisations/remove-organisation.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { NonRetriableError } from 'inngest';
 import { db } from '@/database/client';
 import { createElbaClient } from '@/connectors/elba/client';
-import { organisationsTable, subscriptionsTable } from '@/database/schema'; // oneDriveTable
+import { organisationsTable } from '@/database/schema';
 import { inngest } from '@/inngest/client';
 
 export const removeOrganisation = inngest.createFunction(
@@ -16,9 +16,7 @@ export const removeOrganisation = inngest.createFunction(
   async ({ event, step }) => {
     const { organisationId } = event.data;
     const [organisation] = await db
-      .select({
-        region: organisationsTable.region,
-      })
+      .select({ region: organisationsTable.region })
       .from(organisationsTable)
       .where(eq(organisationsTable.id, organisationId));
 
@@ -26,34 +24,17 @@ export const removeOrganisation = inngest.createFunction(
       throw new NonRetriableError(`Could not retrieve organisation with id=${organisationId}`);
     }
 
-    const subscriptions = await db
-      .select({
-        subscriptionId: subscriptionsTable.subscriptionId,
-      })
-      .from(subscriptionsTable)
-      .where(eq(subscriptionsTable.organisationId, organisationId));
-
-    if (subscriptions.length) {
-      await Promise.all([
-        ...subscriptions.map(({ subscriptionId }) =>
-          step.waitForEvent(`wait-for-remove-subscription-complete-${subscriptionId}`, {
-            event: 'onedrive/subscriptions.remove.completed',
-            timeout: '30d',
-            if: `async.data.organisationId == '${organisationId}' && async.data.subscriptionId == '${subscriptionId}'`,
-          })
-        ),
-        step.sendEvent(
-          'subscription-remove-triggered',
-          subscriptions.map(({ subscriptionId }) => ({
-            name: 'onedrive/subscriptions.remove.triggered',
-            data: {
-              organisationId,
-              subscriptionId,
-            },
-          }))
-        ),
-      ]);
-    }
+    await Promise.all([
+      step.waitForEvent(`wait-for-remove-organisation-subscriptions-complete`, {
+        event: 'onedrive/subscriptions.remove.completed',
+        timeout: '30d',
+        if: `async.data.organisationId == '${organisationId}'`,
+      }),
+      step.sendEvent('subscription-remove-triggered', {
+        name: 'onedrive/subscriptions.remove.triggered',
+        data: { organisationId },
+      }),
+    ]);
 
     const elba = createElbaClient({ organisationId, region: organisation.region });
 

--- a/apps/onedrive/src/inngest/functions/subscriptions/remove-subscription.ts
+++ b/apps/onedrive/src/inngest/functions/subscriptions/remove-subscription.ts
@@ -1,10 +1,11 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { NonRetriableError } from 'inngest';
 import { inngest } from '@/inngest/client';
 import { db } from '@/database/client';
 import { organisationsTable, subscriptionsTable } from '@/database/schema';
 import { removeSubscription as removeOnedriveSubscription } from '@/connectors/microsoft/subscriptions/subscriptions';
 import { decrypt } from '@/common/crypto';
+import { env } from '@/common/env';
 
 export const removeSubscription = inngest.createFunction(
   {
@@ -17,46 +18,72 @@ export const removeSubscription = inngest.createFunction(
     ],
     retries: 5,
     onFailure: async ({ event, step }) => {
-      const { organisationId, subscriptionId } = event.data.event.data;
+      const { organisationId } = event.data.event.data;
 
       await step.sendEvent('subscription-removal-failed', {
         name: 'onedrive/subscriptions.remove.completed',
-        data: { organisationId, subscriptionId },
+        data: { organisationId },
       });
     },
   },
   { event: 'onedrive/subscriptions.remove.triggered' },
   async ({ event, step }) => {
-    const { subscriptionId, organisationId } = event.data;
+    const { organisationId } = event.data;
 
-    const [record] = await db
-      .select({
-        token: organisationsTable.token,
-      })
-      .from(subscriptionsTable)
-      .innerJoin(organisationsTable, eq(subscriptionsTable.organisationId, organisationsTable.id))
-      .where(
-        and(
-          eq(subscriptionsTable.organisationId, organisationId),
-          eq(subscriptionsTable.subscriptionId, subscriptionId)
+    const subscriptionIds = await step.run('get-organisation-subscriptions', async () => {
+      const subscriptions = await db
+        .select({
+          subscriptionId: subscriptionsTable.subscriptionId,
+        })
+        .from(subscriptionsTable)
+        .where(eq(subscriptionsTable.organisationId, organisationId))
+        .orderBy(subscriptionsTable.subscriptionId)
+        .limit(env.SUBSCRIPTION_REMOVAL_BATCH_SIZE);
+
+      return subscriptions.map(({ subscriptionId }) => subscriptionId);
+    });
+
+    if (subscriptionIds.length) {
+      const [organisation] = await db
+        .select({ token: organisationsTable.token })
+        .from(organisationsTable)
+        .where(eq(organisationsTable.id, organisationId));
+
+      if (!organisation) {
+        throw new NonRetriableError(`Could not retrieve organisation with id=${organisationId}`);
+      }
+
+      const token = await decrypt(organisation.token);
+      await Promise.all(
+        subscriptionIds.map((subscriptionId) =>
+          step.run(`remove-subscription-${subscriptionId}`, () =>
+            removeOnedriveSubscription({ token, subscriptionId })
+          )
         )
       );
 
-    if (!record) {
-      throw new NonRetriableError(
-        `Could not retrieve organisation with organisationId=${organisationId} and subscriptionId=${subscriptionId}`
-      );
-    }
+      await db
+        .delete(subscriptionsTable)
+        .where(
+          and(
+            eq(subscriptionsTable.organisationId, organisationId),
+            inArray(subscriptionsTable.subscriptionId, subscriptionIds)
+          )
+        );
 
-    const token = await decrypt(record.token);
-    await removeOnedriveSubscription({ token, subscriptionId });
+      await step.sendEvent('remove-organisation-subscriptions', {
+        name: 'onedrive/subscriptions.remove.triggered',
+        data: { organisationId },
+      });
+
+      return { status: 'ongoing' };
+    }
 
     await step.sendEvent('remove-subscription-completed', {
       name: 'onedrive/subscriptions.remove.completed',
-      data: {
-        subscriptionId,
-        organisationId,
-      },
+      data: { organisationId },
     });
+
+    return { status: 'completed' };
   }
 );

--- a/apps/sharepoint/src/common/env.ts
+++ b/apps/sharepoint/src/common/env.ts
@@ -6,39 +6,40 @@ const MICROSOFT_DATA_PROTECTION_ITEM_SYNC_SIZE_DEFAULT_VALUE = 15;
 
 export const env = z
   .object({
-    MICROSOFT_CLIENT_ID: z.string().min(1),
-    MICROSOFT_CLIENT_SECRET: z.string().min(1),
-    MICROSOFT_REDIRECT_URI: z.string().url(),
-    MICROSOFT_INSTALL_URL: z
-      .string()
-      .url()
-      .default('https://login.microsoftonline.com/organizations/adminconsent'),
-    MICROSOFT_API_URL: z.string().url().default('https://graph.microsoft.com/v1.0'),
-    MICROSOFT_AUTH_API_URL: z.string().url().default('https://login.microsoftonline.com'),
-    MICROSOFT_DATA_PROTECTION_SYNC_CONCURRENCY: zEnvInt().min(1).default(2),
-    MICROSOFT_DATA_PROTECTION_ITEMS_SYNC_CONCURRENCY: zEnvInt().min(1).default(1),
-    MICROSOFT_DATA_PROTECTION_SYNC_CHUNK_SIZE: zEnvInt().min(1).default(100),
-    // We need to set lower value because after fetching items list we will fetch item-permissions without delay
-    MICROSOFT_DATA_PROTECTION_ITEM_SYNC_SIZE: zEnvInt()
-      .min(1)
-      .default(MICROSOFT_DATA_PROTECTION_ITEM_SYNC_SIZE_DEFAULT_VALUE),
-    MICROSOFT_DATA_PROTECTION_CRON_SYNC: z.string().default('0 0 * * 6'),
-    MICROSOFT_DATA_PROTECTION_REFRESH_DELETE_CONCURRENCY: zEnvInt().min(1).default(10),
-    MICROSOFT_CREATE_SUBSCRIPTION_CONCURRENCY: zEnvInt().min(1).default(10),
-    SUBSCRIPTION_EXPIRATION_DAYS: z.string().default('25'),
-    WEBHOOK_URL: z.string().url(),
-    ELBA_API_KEY: z.string().min(1),
+    DATABASE_PROXY_PORT: zEnvInt().optional(),
+    DATABASE_URL: z.string().min(1),
     ELBA_API_BASE_URL: z.string().url(),
+    ELBA_API_KEY: z.string().min(1),
     ELBA_REDIRECT_URL: z.string().url(),
     ELBA_SOURCE_ID: z.string().uuid(),
     ELBA_WEBHOOK_SECRET: z.string().min(1),
     ENCRYPTION_KEY: z.string().min(1),
-    DATABASE_URL: z.string().min(1),
-    DATABASE_PROXY_PORT: zEnvInt().optional(),
-    TOKEN_REFRESH_CRON: z.string().default('*/30 * * * *'),
-    USERS_SYNC_CRON: z.string().default('0 0 * * 1-5'),
-    USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
+    MICROSOFT_API_URL: z.string().url().default('https://graph.microsoft.com/v1.0'),
+    MICROSOFT_AUTH_API_URL: z.string().url().default('https://login.microsoftonline.com'),
+    MICROSOFT_CLIENT_ID: z.string().min(1),
+    MICROSOFT_CLIENT_SECRET: z.string().min(1),
+    MICROSOFT_CREATE_SUBSCRIPTION_CONCURRENCY: zEnvInt().min(1).default(10),
+    MICROSOFT_DATA_PROTECTION_CRON_SYNC: z.string().default('0 0 * * 6'),
+    // We need to set lower value because after fetching items list we will fetch item-permissions without delay
+    MICROSOFT_DATA_PROTECTION_ITEM_SYNC_SIZE: zEnvInt()
+      .min(1)
+      .default(MICROSOFT_DATA_PROTECTION_ITEM_SYNC_SIZE_DEFAULT_VALUE),
+    MICROSOFT_DATA_PROTECTION_ITEMS_SYNC_CONCURRENCY: zEnvInt().min(1).default(1),
+    MICROSOFT_DATA_PROTECTION_REFRESH_DELETE_CONCURRENCY: zEnvInt().min(1).default(10),
+    MICROSOFT_DATA_PROTECTION_SYNC_CHUNK_SIZE: zEnvInt().min(1).default(100),
+    MICROSOFT_DATA_PROTECTION_SYNC_CONCURRENCY: zEnvInt().min(1).default(2),
+    MICROSOFT_INSTALL_URL: z
+      .string()
+      .url()
+      .default('https://login.microsoftonline.com/organizations/adminconsent'),
+    MICROSOFT_REDIRECT_URI: z.string().url(),
     SITES_SYNC_BATCH_SIZE: zEnvInt().default(100),
+    SUBSCRIPTION_EXPIRATION_DAYS: z.string().default('25'),
+    SUBSCRIPTION_REMOVAL_BATCH_SIZE: zEnvInt().default(100),
+    TOKEN_REFRESH_CRON: z.string().default('*/30 * * * *'),
+    USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
+    USERS_SYNC_CRON: z.string().default('0 0 * * 1-5'),
     VERCEL_ENV: z.string().min(1).optional(),
+    WEBHOOK_URL: z.string().url(),
   })
   .parse(process.env);

--- a/apps/sharepoint/src/inngest/client.ts
+++ b/apps/sharepoint/src/inngest/client.ts
@@ -104,13 +104,11 @@ export const inngest = new Inngest({
     };
     'sharepoint/subscriptions.remove.triggered': {
       data: {
-        subscriptionId: string;
         organisationId: string;
       };
     };
     'sharepoint/subscriptions.remove.completed': {
       data: {
-        subscriptionId: string;
         organisationId: string;
       };
     };

--- a/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/sharepoint/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -15,8 +15,8 @@ const organisation = {
   region: 'us',
 };
 
-const sharePoints = Array.from({ length: 5 }, (_, i) => ({
-  organisationId: '45a76301-f1dd-4a77-b12f-9d7d3fca3c90',
+const subscriptions = Array.from({ length: 5 }, (_, i) => ({
+  organisationId: organisation.id,
   siteId: `site-id-${i}`,
   driveId: `drive-id-${i}`,
   subscriptionId: `subscription-id-${i}`,
@@ -40,37 +40,27 @@ describe('remove-organisation', () => {
   test("should remove given organisation when it's registered", async () => {
     const elba = spyOnElba();
     await db.insert(organisationsTable).values(organisation);
-    await db.insert(subscriptionsTable).values(sharePoints);
+    await db.insert(subscriptionsTable).values(subscriptions);
 
     const [result, { step }] = setup({ organisationId: organisation.id });
 
     await expect(result).resolves.toBeUndefined();
 
-    expect(step.waitForEvent).toBeCalledTimes(sharePoints.length);
-
-    for (const [i, subscription] of sharePoints.entries()) {
-      expect(step.waitForEvent).nthCalledWith(
-        i + 1,
-        `wait-for-remove-subscription-complete-${subscription.subscriptionId}`,
-        {
-          event: 'sharepoint/subscriptions.remove.completed',
-          timeout: '30d',
-          if: `async.data.organisationId == '${subscription.organisationId}' && async.data.subscriptionId == '${subscription.subscriptionId}'`,
-        }
-      );
-    }
+    expect(step.waitForEvent).toBeCalledTimes(1);
+    expect(step.waitForEvent).toHaveBeenCalledWith(
+      `wait-for-remove-organisation-subscriptions-complete`,
+      {
+        event: 'sharepoint/subscriptions.remove.completed',
+        timeout: '30d',
+        if: `async.data.organisationId == '${organisation.id}'`,
+      }
+    );
 
     expect(step.sendEvent).toHaveBeenCalledTimes(1);
-    expect(step.sendEvent).toHaveBeenCalledWith(
-      'subscription-remove-triggered',
-      sharePoints.map(({ organisationId, subscriptionId }) => ({
-        name: 'sharepoint/subscriptions.remove.triggered',
-        data: {
-          organisationId,
-          subscriptionId,
-        },
-      }))
-    );
+    expect(step.sendEvent).toHaveBeenCalledWith('subscription-remove-triggered', {
+      name: 'sharepoint/subscriptions.remove.triggered',
+      data: { organisationId: organisation.id },
+    });
 
     expect(elba).toBeCalledTimes(1);
     expect(elba).toBeCalledWith({

--- a/apps/sharepoint/src/inngest/functions/subscriptions/remove-subscription.ts
+++ b/apps/sharepoint/src/inngest/functions/subscriptions/remove-subscription.ts
@@ -1,10 +1,11 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { NonRetriableError } from 'inngest';
 import { inngest } from '@/inngest/client';
 import { db } from '@/database/client';
 import { organisationsTable, subscriptionsTable } from '@/database/schema';
 import { removeSubscription as removeSharepointSubscription } from '@/connectors/microsoft/subscriptions/subscriptions';
 import { decrypt } from '@/common/crypto';
+import { env } from '@/common/env';
 
 export const removeSubscription = inngest.createFunction(
   {
@@ -17,46 +18,72 @@ export const removeSubscription = inngest.createFunction(
     ],
     retries: 5,
     onFailure: async ({ event, step }) => {
-      const { organisationId, subscriptionId } = event.data.event.data;
+      const { organisationId } = event.data.event.data;
 
       await step.sendEvent('subscription-removal-failed', {
         name: 'sharepoint/subscriptions.remove.completed',
-        data: { organisationId, subscriptionId },
+        data: { organisationId },
       });
     },
   },
   { event: 'sharepoint/subscriptions.remove.triggered' },
   async ({ event, step }) => {
-    const { subscriptionId, organisationId } = event.data;
+    const { organisationId } = event.data;
 
-    const [record] = await db
-      .select({
-        token: organisationsTable.token,
-      })
-      .from(subscriptionsTable)
-      .innerJoin(organisationsTable, eq(subscriptionsTable.organisationId, organisationsTable.id))
-      .where(
-        and(
-          eq(subscriptionsTable.organisationId, organisationId),
-          eq(subscriptionsTable.subscriptionId, subscriptionId)
+    const subscriptionIds = await step.run('get-organisation-subscriptions', async () => {
+      const subscriptions = await db
+        .select({
+          subscriptionId: subscriptionsTable.subscriptionId,
+        })
+        .from(subscriptionsTable)
+        .where(eq(subscriptionsTable.organisationId, organisationId))
+        .orderBy(subscriptionsTable.subscriptionId)
+        .limit(env.SUBSCRIPTION_REMOVAL_BATCH_SIZE);
+
+      return subscriptions.map(({ subscriptionId }) => subscriptionId);
+    });
+
+    if (subscriptionIds.length) {
+      const [organisation] = await db
+        .select({ token: organisationsTable.token })
+        .from(organisationsTable)
+        .where(eq(organisationsTable.id, organisationId));
+
+      if (!organisation) {
+        throw new NonRetriableError(`Could not retrieve organisation with id=${organisationId}`);
+      }
+
+      const token = await decrypt(organisation.token);
+      await Promise.all(
+        subscriptionIds.map((subscriptionId) =>
+          step.run(`remove-subscription-${subscriptionId}`, () =>
+            removeSharepointSubscription({ token, subscriptionId })
+          )
         )
       );
 
-    if (!record) {
-      throw new NonRetriableError(
-        `Could not retrieve organisation with organisationId=${organisationId} and subscriptionId=${subscriptionId}`
-      );
-    }
+      await db
+        .delete(subscriptionsTable)
+        .where(
+          and(
+            eq(subscriptionsTable.organisationId, organisationId),
+            inArray(subscriptionsTable.subscriptionId, subscriptionIds)
+          )
+        );
 
-    const token = await decrypt(record.token);
-    await removeSharepointSubscription({ token, subscriptionId });
+      await step.sendEvent('remove-organisation-subscriptions', {
+        name: 'sharepoint/subscriptions.remove.triggered',
+        data: { organisationId },
+      });
+
+      return { status: 'ongoing' };
+    }
 
     await step.sendEvent('remove-subscription-completed', {
       name: 'sharepoint/subscriptions.remove.completed',
-      data: {
-        subscriptionId,
-        organisationId,
-      },
+      data: { organisationId },
     });
+
+    return { status: 'completed' };
   }
 );

--- a/apps/teams/src/env.ts
+++ b/apps/teams/src/env.ts
@@ -43,6 +43,7 @@ export const env = z
     REPLIES_SYNC_MAX_RETRY: zEnvRetry(),
     SUBSCRIBE_EXPIRATION_DAYS: z.string(),
     SUBSCRIBE_SYNC_MAX_RETRY: zEnvRetry(),
+    SUBSCRIPTION_REMOVAL_BATCH_SIZE: z.coerce.number().int().positive().default(100),
     TEAMS_CHANNELS_SYNC_CONCURRENCY: z.coerce.number().int().positive().default(15),
     TEAMS_MESSAGES_SYNC_CONCURRENCY: z.coerce.number().int().positive().default(10),
     TEAMS_REPLIES_SYNC_CONCURRENCY: z.coerce.number().int().positive().default(10),

--- a/apps/teams/src/inngest/client.ts
+++ b/apps/teams/src/inngest/client.ts
@@ -139,13 +139,11 @@ export const inngest = new Inngest({
     };
     'teams/subscriptions.remove.triggered': {
       data: {
-        subscriptionId: string;
         organisationId: string;
       };
     };
     'teams/subscriptions.remove.completed': {
       data: {
-        subscriptionId: string;
         organisationId: string;
       };
     };

--- a/apps/teams/src/inngest/functions/subscriptions/remove-subscription.ts
+++ b/apps/teams/src/inngest/functions/subscriptions/remove-subscription.ts
@@ -1,9 +1,10 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { NonRetriableError } from 'inngest';
 import { inngest } from '@/inngest/client';
 import { db } from '@/database/client';
 import { organisationsTable, subscriptionsTable } from '@/database/schema';
 import { deleteSubscription } from '@/connectors/microsoft/subscriptions/subscriptions';
+import { env } from '@/env';
 
 export const removeSubscription = inngest.createFunction(
   {
@@ -16,45 +17,71 @@ export const removeSubscription = inngest.createFunction(
     ],
     retries: 5,
     onFailure: async ({ event, step }) => {
-      const { organisationId, subscriptionId } = event.data.event.data;
+      const { organisationId } = event.data.event.data;
 
       await step.sendEvent('subscription-removal-failed', {
         name: 'teams/subscriptions.remove.completed',
-        data: { organisationId, subscriptionId },
+        data: { organisationId },
       });
     },
   },
   { event: 'teams/subscriptions.remove.triggered' },
   async ({ event, step }) => {
-    const { subscriptionId, organisationId } = event.data;
+    const { organisationId } = event.data;
 
-    const [record] = await db
-      .select({
-        token: organisationsTable.token,
-      })
-      .from(subscriptionsTable)
-      .innerJoin(organisationsTable, eq(subscriptionsTable.organisationId, organisationsTable.id))
-      .where(
-        and(
-          eq(subscriptionsTable.organisationId, organisationId),
-          eq(subscriptionsTable.id, subscriptionId)
+    const subscriptionIds = await step.run('get-organisation-subscriptions', async () => {
+      const subscriptions = await db
+        .select({
+          subscriptionId: subscriptionsTable.id,
+        })
+        .from(subscriptionsTable)
+        .where(eq(subscriptionsTable.organisationId, organisationId))
+        .orderBy(subscriptionsTable.id)
+        .limit(env.SUBSCRIPTION_REMOVAL_BATCH_SIZE);
+
+      return subscriptions.map(({ subscriptionId }) => subscriptionId);
+    });
+
+    if (subscriptionIds.length) {
+      const [organisation] = await db
+        .select({ token: organisationsTable.token })
+        .from(organisationsTable)
+        .where(eq(organisationsTable.id, organisationId));
+
+      if (!organisation) {
+        throw new NonRetriableError(`Could not retrieve organisation with id=${organisationId}`);
+      }
+
+      await Promise.all(
+        subscriptionIds.map((subscriptionId) =>
+          step.run(`remove-subscription-${subscriptionId}`, () =>
+            deleteSubscription(organisation.token, subscriptionId)
+          )
         )
       );
 
-    if (!record) {
-      throw new NonRetriableError(
-        `Could not retrieve organisation with organisationId=${organisationId} and subscriptionId=${subscriptionId}`
-      );
-    }
+      await db
+        .delete(subscriptionsTable)
+        .where(
+          and(
+            eq(subscriptionsTable.organisationId, organisationId),
+            inArray(subscriptionsTable.id, subscriptionIds)
+          )
+        );
 
-    await deleteSubscription(record.token, subscriptionId);
+      await step.sendEvent('remove-organisation-subscriptions', {
+        name: 'teams/subscriptions.remove.triggered',
+        data: { organisationId },
+      });
+
+      return { status: 'ongoing' };
+    }
 
     await step.sendEvent('remove-subscription-completed', {
       name: 'teams/subscriptions.remove.completed',
-      data: {
-        subscriptionId,
-        organisationId,
-      },
+      data: { organisationId },
     });
+
+    return { status: 'completed' };
   }
 );


### PR DESCRIPTION
## Description

This fixes OneDrive, SharePoint & Teams subscription removal. Some organisation could have hundreds of subscriptions, which could result in organisation removal failures as we would reach Inngest steps limit.
The logic has been updated to have an event that will retrieve a subscriptions batch in database, and recursively call itself till there is not subscription anymore, and send a 'completed' event.

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
