### PR TITLE
chore(dropbox-updatedAt): include updatedAt property for files

### DIFF
--- a/apps/dropbox/src/connectors/elba/data-protection/files.ts
+++ b/apps/dropbox/src/connectors/elba/data-protection/files.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { type DataProtectionPermission } from '@elba-security/schemas';
+import { type DataProtectionObject } from '@elba-security/sdk';
 import { type File } from '@/connectors/dropbox/folders-and-files';
 import { type FolderAndFilePermissions } from './permissions';
 
@@ -39,7 +40,7 @@ export const formatFilesToAdd = ({
 }: {
   files: FileToAdd[];
   teamMemberId: string;
-}) => {
+}): DataProtectionObject[] => {
   return files.flatMap((file) => {
     const sourceOwner = file.permissions.find((permission) => permission.role === 'owner');
     const isPersonal = sourceOwner?.team_member_id === teamMemberId;
@@ -60,6 +61,7 @@ export const formatFilesToAdd = ({
       ownerId: teamMemberId,
       url: file.metadata.preview_url,
       contentHash: file.content_hash,
+      updatedAt: file.server_modified,
       metadata: {
         ownerId: teamMemberId,
         isPersonal,
@@ -73,6 +75,6 @@ export const formatFilesToAdd = ({
           metadata,
         };
       }) as DataProtectionPermission[],
-    };
+    } as const satisfies DataProtectionObject;
   });
 };

--- a/apps/dropbox/src/connectors/elba/data-protection/folders.ts
+++ b/apps/dropbox/src/connectors/elba/data-protection/folders.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { type DataProtectionPermission } from '@elba-security/schemas';
+import { type DataProtectionObject } from '@elba-security/sdk';
 import { type Folder } from '@/connectors/dropbox/folders-and-files';
 import { type FolderAndFilePermissions } from './permissions';
 
@@ -37,7 +38,7 @@ export const formatFoldersToAdd = ({
 }: {
   folders: FolderToAdd[];
   teamMemberId: string;
-}) => {
+}): DataProtectionObject[] => {
   return folders.flatMap((folder) => {
     const sourceOwner = folder.permissions.find((permission) => permission.role === 'owner');
     const isPersonal = sourceOwner?.team_member_id === teamMemberId;
@@ -75,6 +76,6 @@ export const formatFoldersToAdd = ({
           metadata,
         };
       }) as DataProtectionPermission[],
-    };
+    } as const satisfies DataProtectionObject;
   });
 };

--- a/apps/dropbox/src/inngest/functions/data-protections/__mocks__/sync-folder-and-files.ts
+++ b/apps/dropbox/src/inngest/functions/data-protections/__mocks__/sync-folder-and-files.ts
@@ -74,6 +74,7 @@ export const mockGetFilesMetadataMembersAndMapDetails: GetFilesMetadataMembersAn
     },
     name: 'file-1.pdf',
     ownerId: 'dbmid:team-member-id-1',
+    updatedAt: '2021-09-01T00:00:00Z',
     permissions: [
       {
         email: 'team-member-email-1@foo.com',
@@ -93,6 +94,7 @@ export const mockGetFilesMetadataMembersAndMapDetails: GetFilesMetadataMembersAn
     },
     name: 'file-2.pdf',
     ownerId: 'dbmid:team-member-id-1',
+    updatedAt: '2021-09-01T00:00:00Z',
     permissions: [
       {
         email: 'team-member-email-1@foo.com',
@@ -211,6 +213,7 @@ export const mockElbaObject = [
     },
     name: 'file-1.pdf',
     ownerId: 'dbmid:team-member-id-1',
+    updatedAt: '2021-09-01T00:00:00Z',
     permissions: [
       {
         email: 'team-member-email-1@foo.com',
@@ -230,6 +233,7 @@ export const mockElbaObject = [
     },
     name: 'file-2.pdf',
     ownerId: 'dbmid:team-member-id-1',
+    updatedAt: '2021-09-01T00:00:00Z',
     permissions: [
       {
         email: 'team-member-email-1@foo.com',


### PR DESCRIPTION
## Description

In the early implementation `updatedAt` property wasn't sent to files,  in this PR it is added
## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
