### PR TITLE
fix(google): ignore invalid user emails

### DIFF
--- a/apps/google/src/connectors/google/users.ts
+++ b/apps/google/src/connectors/google/users.ts
@@ -15,8 +15,13 @@ export const googleUserSchema = z.object({
   emails: z
     .array(
       z.object({
-        address: z.string().email(),
+        address: z.string(),
       })
+    )
+    // As the additional emails could have invalid format like `*@domain.local`
+    // We use zod transform to filter out invalid emails and avoid user parsing failure
+    .transform((emails) =>
+      emails.filter((email) => z.string().email().safeParse(email.address).success)
     )
     .optional(),
   isEnrolledIn2Sv: z.boolean().optional(),


### PR DESCRIPTION
## Description

This fixes Google users zod validation. Some users could have weirdly formatted additional email addresses like `*@domain.local` which would break zod validation.

Now the user is now properly parsed without exception ignoring these invalid emails 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
