### PR TITLE
chore(google): personal drive sync optimization

### DIFF
--- a/apps/google/src/connectors/google/files.ts
+++ b/apps/google/src/connectors/google/files.ts
@@ -7,11 +7,12 @@ export const googleFileSchema = z.object({
   name: z.string().min(1),
   sha256Checksum: z.string().min(1).optional(),
   viewedByMeTime: z.string().min(1).optional(),
+  shared: z.boolean().optional(),
 });
 
 export type GoogleFile = zInfer<typeof googleFileSchema>;
 
-const googleFileFields = ['id', 'name', 'sha256Checksum', 'viewedByMeTime'];
+const googleFileFields = ['id', 'name', 'sha256Checksum', 'viewedByMeTime', 'shared'];
 
 export const getGoogleFile = async ({
   fields = googleFileFields.join(','),

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
@@ -23,10 +23,16 @@ describe('sync-data-protection-drive', () => {
           name: 'file 1',
           sha256Checksum: 'sha256-checksum-1',
           viewedByMeTime: '2024-01-01T00:00:00Z',
+          shared: true,
         },
         {
           id: 'file-id-2',
           name: 'file 2',
+        },
+        {
+          id: 'file-id-3',
+          name: 'file 3 not shared',
+          shared: false,
         },
       ],
       nextPageToken: 'next-page-token',
@@ -176,10 +182,16 @@ describe('sync-data-protection-drive', () => {
           name: 'file 1',
           sha256Checksum: 'sha256-checksum-1',
           viewedByMeTime: '2024-01-01T00:00:00Z',
+          shared: true,
         },
         {
           id: 'file-id-2',
           name: 'file 2',
+        },
+        {
+          id: 'file-id-3',
+          name: 'file 3 not shared',
+          shared: false,
         },
       ],
       nextPageToken: null,


### PR DESCRIPTION
## Description

This improves Google data protection sync. We now use the `shared` file attribute to know if a file is shared or not. This attribute only works for personal drives. When the file is not shared, we avoid retrieving its permissions and sending it. By consequence, personal drives sync speed should be improved

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by
checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand
areas.
- [ ] I have added tests to cover the new feature or fixes.
