### PR TITLE
feat(google): ingest file last modified date from Google Drive

### DIFF
--- a/apps/google/src/connectors/elba/data-protection.ts
+++ b/apps/google/src/connectors/elba/data-protection.ts
@@ -25,6 +25,7 @@ export const formatDataProtectionObject = ({
     ownerId: owner,
     url: `https://drive.google.com/open?id=${file.id}`,
     lastAccessedAt: file.viewedByMeTime,
+    updatedAt: file.modifiedTime,
     contentHash: file.sha256Checksum,
     permissions: permissions.map((permission) => formatDataProtectionObjectPermission(permission)),
     metadata: {

--- a/apps/google/src/connectors/google/files.ts
+++ b/apps/google/src/connectors/google/files.ts
@@ -7,12 +7,20 @@ export const googleFileSchema = z.object({
   name: z.string().min(1),
   sha256Checksum: z.string().min(1).optional(),
   viewedByMeTime: z.string().min(1).optional(),
+  modifiedTime: z.string().min(1).optional(),
   shared: z.boolean().optional(),
 });
 
 export type GoogleFile = zInfer<typeof googleFileSchema>;
 
-const googleFileFields = ['id', 'name', 'sha256Checksum', 'viewedByMeTime', 'shared'];
+const googleFileFields = [
+  'id',
+  'name',
+  'sha256Checksum',
+  'viewedByMeTime',
+  'modifiedTime',
+  'shared',
+];
 
 export const getGoogleFile = async ({
   fields = googleFileFields.join(','),

--- a/apps/google/src/inngest/functions/data-protection/refresh-object.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/refresh-object.test.ts
@@ -23,7 +23,8 @@ describe('refresh-data-protection-object', () => {
         id: fileId as unknown as string,
         name: 'file-name',
         sha256Checksum: 'sha256-checksum',
-        viewedByMeTime: '2024-01-01T00:00:00Z',
+        viewedByMeTime: '2024-01-02T00:00:00Z',
+        modifiedTime: '2024-01-01T00:00:00Z',
       });
     });
 
@@ -102,7 +103,8 @@ describe('refresh-data-protection-object', () => {
         {
           contentHash: 'sha256-checksum',
           id: 'object-id',
-          lastAccessedAt: '2024-01-01T00:00:00Z',
+          lastAccessedAt: '2024-01-02T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
           metadata: {
             ownerId: 'user-id',
           },

--- a/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
+++ b/apps/google/src/inngest/functions/data-protection/sync-drive.test.ts
@@ -22,7 +22,8 @@ describe('sync-data-protection-drive', () => {
           id: 'file-id-1',
           name: 'file 1',
           sha256Checksum: 'sha256-checksum-1',
-          viewedByMeTime: '2024-01-01T00:00:00Z',
+          viewedByMeTime: '2024-01-02T00:00:00Z',
+          modifiedTime: '2024-01-01T00:00:00Z',
           shared: true,
         },
         {
@@ -112,7 +113,8 @@ describe('sync-data-protection-drive', () => {
         {
           contentHash: 'sha256-checksum-1',
           id: 'file-id-1',
-          lastAccessedAt: '2024-01-01T00:00:00Z',
+          lastAccessedAt: '2024-01-02T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
           metadata: {
             ownerId: 'user-id-1',
           },
@@ -181,7 +183,8 @@ describe('sync-data-protection-drive', () => {
           id: 'file-id-1',
           name: 'file 1',
           sha256Checksum: 'sha256-checksum-1',
-          viewedByMeTime: '2024-01-01T00:00:00Z',
+          viewedByMeTime: '2024-01-02T00:00:00Z',
+          modifiedTime: '2024-01-01T00:00:00Z',
           shared: true,
         },
         {
@@ -276,7 +279,8 @@ describe('sync-data-protection-drive', () => {
         {
           contentHash: 'sha256-checksum-1',
           id: 'file-id-1',
-          lastAccessedAt: '2024-01-01T00:00:00Z',
+          lastAccessedAt: '2024-01-02T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
           metadata: {
             ownerId: 'user-id-1',
           },


### PR DESCRIPTION
## Description

This change introduces the ingestion of the `modifiedTime` field from the Google API into the `updatedAt` field of elba's data protection object.

The changes include:
-  Updating the Google file Zod schema to incorporate the `modifiedTime` field.
-  Requesting the `modifiedTime` field from Google's API.
-  Properly mapping the `modifiedTime` field from Google to Elba's `updatedAt` object.

This change is done to track the last time a file was updated by any user with permissions, allowing elba to take appropriate actions based on this data point.

Completes E-3207.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.