### PR TITLE
feat(gong): list users, pagination, rate limit

### DIFF
--- a/apps/gong/.env.test
+++ b/apps/gong/.env.test
@@ -1,0 +1,8 @@
+ELBA_SOURCE_ID="0442f541-45d2-487a-9e4b-de03ce4c559e"
+ELBA_API_KEY="elba-api-key-gong"
+ELBA_API_BASE_URL="http://localhost:3522/api/rest"
+ELBA_WEBHOOK_SECRET="elba-webhook-secret-gong"
+GONG_API_BASE_URL="https://api.gong.io"
+GONG_USERS_SYNC_CRON="0 0 * * *"
+NANGO_INTEGRATION_ID="gong-sandbox"
+NANGO_SECRET_KEY="nango-secret-key"

--- a/apps/gong/.eslintrc.js
+++ b/apps/gong/.eslintrc.js
@@ -1,0 +1,17 @@
+const { resolve } = require('node:path');
+
+const project = resolve(__dirname, './tsconfig.json');
+
+module.exports = {
+  extends: ['@elba-security/eslint-config-custom/next'],
+  parserOptions: {
+    project,
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project,
+      },
+    },
+  },
+};

--- a/apps/gong/.gitignore
+++ b/apps/gong/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/gong/README.md
+++ b/apps/gong/README.md
@@ -1,0 +1,73 @@
+## Getting Started
+
+Rename `.env.local.example` to `.env.local`.
+
+This file will be used for local development environment.
+
+### Setting up node integration
+
+If your integration does not support **edge runtime** some files has to be edited:
+
+- `docker-compose.yml`: remove the `pg_proxy` service
+- `vitest/setup-msw-handlers`: remove the first arguments of `setupServer()`, setting a passthrough
+- `src/database/client.ts`: replace this file by `client.node.ts` (and remove it)
+- `vitest.config.js`: update `environment` to `'node'`
+- `package.json`: remove dependency `"@neondatabase/serverless"`
+- remove each `route.ts` exports of `preferredRegion` & `runtime` constants.
+
+### Setting up edge-runtime integration
+
+If your integration does supports **edge runtime** you just have to remove file ending with `.node.ts` like `src/database/client.node.ts`.
+
+### Running the integration
+
+First of all, ensure that the PostgreSQL database is running. You can start it by executing the following command:
+
+```bash
+pnpm database:up
+```
+
+To apply the migration, run:
+
+```bash
+pnpm database:migrate
+```
+
+Next, run the nextjs development server with the command:
+
+```bash
+pnpm dev
+```
+
+To be able to run Inngest functions, it's essential to have a local Inngest client operational. Start it using:
+
+```bash
+pnpm dev:inngest
+```
+
+_Once the Inngest client is running, it will send requests to the `localhost:4000/api/inngest` route to gather information about your functions, including events and cron triggers. Inngest also provides a user interface, accessible in your web browser, where you can monitor function invocations, attempt retries, and more._
+
+### Database migrations
+
+To create a new migration file within the `/drizzle` directory, execute the following command:
+
+```bash
+pnpm database:generate
+```
+
+After generating the migration, apply it by running:
+
+```bash
+pnpm database:migrate
+```
+
+Important Considerations:
+
+- **Single Migration Requirement**: Your integration should include only one migration before merging into the staging environment. If you need to regenerate the contents of your `/drizzle` folder, ensure that you delete the existing folder first.
+
+- **Handling drizzle-orm Errors**: In cases where `drizzle-orm` encounters an error during the migration process, it's advisable to unmount and remount your database container. This can be achieved with the `database:down` and `database:up` commands, respectively. Once this is done, you can attempt the migration again.
+
+### Example implementation
+
+The template contains an example implementation that will guide you to reach our requirements. Make sure
+to adapt this example to your need and remove the disclamer comments before creating your first PR.

--- a/apps/gong/next.config.js
+++ b/apps/gong/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const { elbaNextConfig } = require('@elba-security/config/next');
+
+const nextConfig = {
+  ...elbaNextConfig,
+  transpilePackages: ['@elba-security/sdk'],
+};
+
+module.exports = nextConfig;

--- a/apps/gong/package.json
+++ b/apps/gong/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@elba-security/gong",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 4000",
+    "dev:inngest": "inngest-cli dev -u http://localhost:4000/api/inngest",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elba-security/config": "workspace:*",
+    "@elba-security/inngest": "workspace:*",
+    "@elba-security/logger": "workspace:*",
+    "@elba-security/nango": "workspace:*",
+    "@elba-security/nextjs": "workspace:*",
+    "@elba-security/sdk": "workspace:*",
+    "inngest": "catalog:",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "catalog:",
+    "@elba-security/eslint-config-custom": "workspace:*",
+    "@elba-security/test-utils": "workspace:*",
+    "@elba-security/tsconfig": "workspace:*",
+    "@next/eslint-plugin-next": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "dotenv": "catalog:",
+    "eslint": "catalog:",
+    "msw": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/gong/src/app/api/inngest/route.ts
+++ b/apps/gong/src/app/api/inngest/route.ts
@@ -1,0 +1,13 @@
+import { serve } from 'inngest/next';
+import { inngest } from '@/inngest/client';
+import { inngestFunctions } from '@/inngest/functions';
+
+export const preferredRegion = 'iad1';
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export const { GET, POST, PUT } = serve({
+  client: inngest,
+  functions: inngestFunctions,
+  streaming: 'allow',
+});

--- a/apps/gong/src/app/api/webhooks/elba/installation/validate/route.ts
+++ b/apps/gong/src/app/api/webhooks/elba/installation/validate/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { parseWebhookEventData } from '@elba-security/sdk';
+import { validateSourceInstallation } from './service';
+
+export async function POST(request: NextRequest) {
+  const data: unknown = await request.json();
+  const { organisationId, region, nangoConnectionId } = parseWebhookEventData(
+    'installation.validation.requested',
+    data
+  );
+
+  const result = await validateSourceInstallation({ organisationId, region, nangoConnectionId });
+
+  return NextResponse.json(result);
+}

--- a/apps/gong/src/app/api/webhooks/elba/installation/validate/service.test.ts
+++ b/apps/gong/src/app/api/webhooks/elba/installation/validate/service.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { spyOnElba } from '@elba-security/test-utils';
+import { inngest } from '@/inngest/client';
+import * as usersConnector from '@/connectors/gong/users';
+import * as nangoAPI from '@/common/nango';
+import { validateSourceInstallation } from './service';
+
+const organisationId = '00000000-0000-0000-0000-000000000002';
+const region = 'us';
+const nangoConnectionId = 'nango-connection-id';
+const now = Date.now();
+
+describe('validateSourceInstallation', () => {
+  beforeAll(() => {
+    vi.setSystemTime(now);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it('should send request to sync the users and set the elba connection error null', async () => {
+    const elba = spyOnElba();
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
+      getConnection: vi.fn().mockResolvedValue({
+        credentials: { access_token: 'access-token' },
+      }),
+    });
+
+    const send = vi.spyOn(inngest, 'send').mockResolvedValue({ ids: [] });
+    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
+      authUserUrl: 'https://test-url.gong.com',
+    });
+
+    await validateSourceInstallation({
+      organisationId,
+      nangoConnectionId,
+      region,
+    });
+
+    expect(send).toBeCalledTimes(1);
+    expect(send).toBeCalledWith([
+      {
+        name: 'gong/app.installed',
+        data: {
+          organisationId,
+        },
+      },
+      {
+        name: 'gong/users.sync.requested',
+        data: {
+          organisationId,
+          region,
+          nangoConnectionId,
+          isFirstSync: true,
+          syncStartedAt: now,
+          page: null,
+        },
+      },
+    ]);
+    const elbaInstance = elba.mock.results[0]?.value;
+    expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
+      errorType: null,
+    });
+  });
+
+  it('should throw an error when when auth user is not an Owner or Admin', async () => {
+    const elba = spyOnElba();
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
+      getConnection: vi.fn().mockResolvedValue({
+        credentials: { access_token: 'access-token' },
+      }),
+    });
+
+    await expect(
+      validateSourceInstallation({
+        organisationId,
+        nangoConnectionId,
+        region,
+      })
+    ).resolves.toStrictEqual({
+      message: 'Source installation validation failed',
+    });
+
+    const elbaInstance = elba.mock.results[0]?.value;
+    expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
+      errorMetadata: {
+        name: 'GongError',
+        cause: undefined,
+        message: '',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- convenience
+        stack: expect.any(String),
+      },
+      errorType: 'not_admin',
+    });
+  });
+  it('should throw an error when the nango credentials are not valid', async () => {
+    const elba = spyOnElba();
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
+      getConnection: vi.fn().mockResolvedValue({
+        credentials: {},
+      }),
+    });
+
+    await expect(
+      validateSourceInstallation({
+        organisationId,
+        nangoConnectionId,
+        region,
+      })
+    ).resolves.toStrictEqual({
+      message: 'Source installation validation failed',
+    });
+
+    const elbaInstance = elba.mock.results[0]?.value;
+    expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
+      errorMetadata: {
+        name: 'Error',
+        cause: undefined,
+        message: 'Could not retrieve Nango credentials',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- convenience
+        stack: expect.any(String),
+      },
+      errorType: 'unknown',
+    });
+  });
+});

--- a/apps/gong/src/app/api/webhooks/elba/installation/validate/service.ts
+++ b/apps/gong/src/app/api/webhooks/elba/installation/validate/service.ts
@@ -1,0 +1,77 @@
+import { serializeLogObject } from '@elba-security/logger/src/serialize';
+import { logger } from '@elba-security/logger';
+import { nangoAPIClient } from '@/common/nango';
+import { getUsers } from '@/connectors/gong/users';
+import { nangoCredentialsSchema } from '@/connectors/common/nango';
+import { createElbaOrganisationClient } from '@/connectors/elba/client';
+import { inngest } from '@/inngest/client';
+import { mapElbaConnectionError } from '@/connectors/common/error';
+
+export const validateSourceInstallation = async ({
+  organisationId,
+  region,
+  nangoConnectionId,
+}: {
+  organisationId: string;
+  region: string;
+  nangoConnectionId: string;
+}) => {
+  const elba = createElbaOrganisationClient({
+    organisationId,
+    region,
+  });
+  try {
+    const { credentials } = await nangoAPIClient.getConnection(nangoConnectionId);
+    
+        const nangoCredentialsResult = nangoCredentialsSchema.safeParse(credentials);
+    
+        if (!nangoCredentialsResult.success) {
+          throw new Error('Could not retrieve Nango credentials');
+        }
+
+    await getUsers({
+      userName: nangoCredentialsResult.data.username,
+      password: nangoCredentialsResult.data.password,
+    });
+    await elba.connectionStatus.update({
+      errorType: null,
+    });
+
+    await inngest.send([
+      {
+        name: 'gong/app.installed',
+        data: {
+          organisationId,
+        },
+      },
+      {
+        name: 'gong/users.sync.requested',
+        data: {
+          organisationId,
+          region,
+          nangoConnectionId,
+          isFirstSync: true,
+          syncStartedAt: Date.now(),
+          page: null,
+        },
+      },
+    ]);
+
+    return { message: 'Source installation validated' };
+  } catch (error) {
+    logger.error('Failed to validate installation', {
+      organisationId,
+      region,
+      nangoConnectionId,
+      error,
+    });
+
+    const errorType = mapElbaConnectionError(error);
+    await elba.connectionStatus.update({
+      errorType: errorType || 'unknown',
+      errorMetadata: serializeLogObject(error),
+    });
+
+    return { message: 'Source installation validation failed' };
+  }
+};

--- a/apps/gong/src/app/layout.tsx
+++ b/apps/gong/src/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Elba x Gong',
+  description: 'Elba x Gong integration',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/gong/src/app/page.tsx
+++ b/apps/gong/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>Elba x Gong</main>;
+}

--- a/apps/gong/src/common/env.ts
+++ b/apps/gong/src/common/env.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+const zEnvInt = () => z.coerce.number().int().positive();
+
+export const env = z
+  .object({
+    ELBA_API_KEY: z.string().min(1),
+    ELBA_API_BASE_URL: z.string().url(),
+    ELBA_SOURCE_ID: z.string().uuid(),
+    ELBA_WEBHOOK_SECRET: z.string().min(1),
+    GONG_API_BASE_URL: z.string().url(),
+    GONG_DELETE_USER_CONCURRENCY: zEnvInt().default(5),
+    GONG_USERS_SYNC_CRON: z.string().default('0 0 * * *'),
+    NANGO_INTEGRATION_ID: z.string().min(1),
+    NANGO_SECRET_KEY: z.string().min(1),
+  })
+  .parse(process.env);

--- a/apps/gong/src/common/nango.ts
+++ b/apps/gong/src/common/nango.ts
@@ -1,0 +1,7 @@
+import { NangoAPIClient } from '@elba-security/nango';
+import { env } from './env';
+
+export const nangoAPIClient = new NangoAPIClient({
+  integrationId: env.NANGO_INTEGRATION_ID,
+  secretKey: env.NANGO_SECRET_KEY,
+});

--- a/apps/gong/src/connectors/common/error.ts
+++ b/apps/gong/src/connectors/common/error.ts
@@ -1,0 +1,25 @@
+import { type MapConnectionErrorFn } from '@elba-security/inngest';
+import { NangoConnectionError } from '@elba-security/nango';
+
+type GongErrorOptions = { response?: Response };
+
+export class GongError extends Error {
+  response?: Response;
+
+  constructor(message: string, { response }: GongErrorOptions = {}) {
+    super(message);
+    this.response = response;
+    this.name = 'GongError';
+  }
+}
+
+export const mapElbaConnectionError: MapConnectionErrorFn = (error) => {
+  if (error instanceof NangoConnectionError && error.response.status === 404) {
+    return 'unauthorized';
+  }
+  if (error instanceof GongError && error.response?.status === 401) {
+    return 'unauthorized';
+  }
+
+  return null;
+};

--- a/apps/gong/src/connectors/common/nango.ts
+++ b/apps/gong/src/connectors/common/nango.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const nangoCredentialsSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});

--- a/apps/gong/src/connectors/elba/client.ts
+++ b/apps/gong/src/connectors/elba/client.ts
@@ -1,0 +1,25 @@
+import { Elba } from '@elba-security/sdk';
+import { env } from '@/common/env';
+
+export const createElbaOrganisationClient = ({
+  organisationId,
+  region,
+}: {
+  organisationId: string;
+  region: string;
+}) => {
+  return new Elba({
+    organisationId,
+    apiKey: env.ELBA_API_KEY,
+    baseUrl: env.ELBA_API_BASE_URL,
+    region,
+  });
+};
+
+export const createElbaGlobalClient = (region: string) => {
+  return new Elba({
+    apiKey: env.ELBA_API_KEY,
+    baseUrl: env.ELBA_API_BASE_URL,
+    region,
+  });
+};

--- a/apps/gong/src/connectors/gong/users.test.ts
+++ b/apps/gong/src/connectors/gong/users.test.ts
@@ -4,19 +4,20 @@ import { server } from '@elba-security/test-utils';
 import { env } from '@/common/env';
 import { GongError } from '../common/error';
 import type { GongUser } from './users';
-import { getUsers, deleteUser } from './users';
+import { getUsers } from './users';
 
-const validToken = 'token-1234';
-const endPageOffset = '3';
-const nextPageOffset = '2';
-const userId = 'test-user-id';
+const userName = 'username-1234';
+const password = 'password-1234';
+const endPageCursor = 'end-page-cursor';
+const nextPageCursor = 'next-page-cursor';
+const validEncodedKey = btoa(`${userName}:${password}`);
 
 const validUsers: GongUser[] = Array.from({ length: 5 }, (_, i) => ({
   id: `id-${i}`,
-  name: `userName-${i}`,
-  role: 'owner',
-  email: `user-${i}@foo.bar`,
-  invitation_sent: false,
+  firstName: `firstName-${i}`,
+  lastName: `lastName-${i}`,
+  emailAddress: `user-${i}@foo.bar`,
+  active: false,
 }));
 
 const invalidUsers = [];
@@ -25,17 +26,21 @@ describe('users connector', () => {
   describe('getUsers', () => {
     beforeEach(() => {
       server.use(
-        http.get(`${env.GONG_API_BASE_URL}/users`, ({ request }) => {
-          if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+        http.get(`${env.GONG_API_BASE_URL}/v2/users`, ({ request }) => {
+          if (request.headers.get('Authorization') !== `Basic ${validEncodedKey}`) {
             return new Response(undefined, { status: 401 });
           }
 
           const url = new URL(request.url);
-          const offset = url.searchParams.get('offset') || '0';
+          const cursor = url.searchParams.get('cursor');
           const responseData = {
             users: validUsers,
-            offset: parseInt(offset, 10),
-            more: offset !== endPageOffset,
+            records:
+              cursor !== endPageCursor
+                ? {
+                    cursor: nextPageCursor,
+                  }
+                : {},
           };
           return Response.json(responseData);
         })
@@ -43,19 +48,15 @@ describe('users connector', () => {
     });
 
     test('should return users and nextPage when the token is valid and their is another page', async () => {
-      await expect(
-        getUsers({ accessToken: validToken, page: nextPageOffset })
-      ).resolves.toStrictEqual({
+      await expect(getUsers({ userName, password, page: nextPageCursor })).resolves.toStrictEqual({
         validUsers,
         invalidUsers,
-        nextPage: parseInt(nextPageOffset, 10) + 1,
+        nextPage: nextPageCursor,
       });
     });
 
     test('should return users and no nextPage when the token is valid and their is no other page', async () => {
-      await expect(
-        getUsers({ accessToken: validToken, page: endPageOffset })
-      ).resolves.toStrictEqual({
+      await expect(getUsers({ userName, password, page: endPageCursor })).resolves.toStrictEqual({
         validUsers,
         invalidUsers,
         nextPage: null,
@@ -63,37 +64,7 @@ describe('users connector', () => {
     });
 
     test('should throws when the token is invalid', async () => {
-      await expect(getUsers({ accessToken: 'foo-bar' })).rejects.toBeInstanceOf(GongError);
-    });
-  });
-
-  describe('deleteUser', () => {
-    beforeEach(() => {
-      server.use(
-        http.delete<{ userId: string }>(
-          `${env.GONG_API_BASE_URL}/users/${userId}`,
-          ({ request }) => {
-            if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
-              return new Response(undefined, { status: 401 });
-            }
-            return new Response(undefined, { status: 200 });
-          }
-        )
-      );
-    });
-
-    test('should delete user successfully when token is valid', async () => {
-      await expect(deleteUser({ accessToken: validToken, userId })).resolves.not.toThrow();
-    });
-
-    test('should not throw when the user is not found', async () => {
-      await expect(deleteUser({ accessToken: validToken, userId })).resolves.toBeUndefined();
-    });
-
-    test('should throw GongError when token is invalid', async () => {
-      await expect(deleteUser({ accessToken: 'invalidToken', userId })).rejects.toBeInstanceOf(
-        GongError
-      );
+      await expect(getUsers({ userName, password: 'foo-bar' })).rejects.toBeInstanceOf(GongError);
     });
   });
 });

--- a/apps/gong/src/connectors/gong/users.test.ts
+++ b/apps/gong/src/connectors/gong/users.test.ts
@@ -1,0 +1,99 @@
+import { http } from 'msw';
+import { describe, expect, test, beforeEach } from 'vitest';
+import { server } from '@elba-security/test-utils';
+import { env } from '@/common/env';
+import { GongError } from '../common/error';
+import type { GongUser } from './users';
+import { getUsers, deleteUser } from './users';
+
+const validToken = 'token-1234';
+const endPageOffset = '3';
+const nextPageOffset = '2';
+const userId = 'test-user-id';
+
+const validUsers: GongUser[] = Array.from({ length: 5 }, (_, i) => ({
+  id: `id-${i}`,
+  name: `userName-${i}`,
+  role: 'owner',
+  email: `user-${i}@foo.bar`,
+  invitation_sent: false,
+}));
+
+const invalidUsers = [];
+
+describe('users connector', () => {
+  describe('getUsers', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${env.GONG_API_BASE_URL}/users`, ({ request }) => {
+          if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+            return new Response(undefined, { status: 401 });
+          }
+
+          const url = new URL(request.url);
+          const offset = url.searchParams.get('offset') || '0';
+          const responseData = {
+            users: validUsers,
+            offset: parseInt(offset, 10),
+            more: offset !== endPageOffset,
+          };
+          return Response.json(responseData);
+        })
+      );
+    });
+
+    test('should return users and nextPage when the token is valid and their is another page', async () => {
+      await expect(
+        getUsers({ accessToken: validToken, page: nextPageOffset })
+      ).resolves.toStrictEqual({
+        validUsers,
+        invalidUsers,
+        nextPage: parseInt(nextPageOffset, 10) + 1,
+      });
+    });
+
+    test('should return users and no nextPage when the token is valid and their is no other page', async () => {
+      await expect(
+        getUsers({ accessToken: validToken, page: endPageOffset })
+      ).resolves.toStrictEqual({
+        validUsers,
+        invalidUsers,
+        nextPage: null,
+      });
+    });
+
+    test('should throws when the token is invalid', async () => {
+      await expect(getUsers({ accessToken: 'foo-bar' })).rejects.toBeInstanceOf(GongError);
+    });
+  });
+
+  describe('deleteUser', () => {
+    beforeEach(() => {
+      server.use(
+        http.delete<{ userId: string }>(
+          `${env.GONG_API_BASE_URL}/users/${userId}`,
+          ({ request }) => {
+            if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+              return new Response(undefined, { status: 401 });
+            }
+            return new Response(undefined, { status: 200 });
+          }
+        )
+      );
+    });
+
+    test('should delete user successfully when token is valid', async () => {
+      await expect(deleteUser({ accessToken: validToken, userId })).resolves.not.toThrow();
+    });
+
+    test('should not throw when the user is not found', async () => {
+      await expect(deleteUser({ accessToken: validToken, userId })).resolves.toBeUndefined();
+    });
+
+    test('should throw GongError when token is invalid', async () => {
+      await expect(deleteUser({ accessToken: 'invalidToken', userId })).rejects.toBeInstanceOf(
+        GongError
+      );
+    });
+  });
+});

--- a/apps/gong/src/connectors/gong/users.ts
+++ b/apps/gong/src/connectors/gong/users.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import { env } from '@/common/env';
+import { GongError } from '../common/error';
+
+const gongUserSchema = z.object({
+  id: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  emailAddress: z.string(),
+  active: z.boolean(),
+});
+
+export type GongUser = z.infer<typeof gongUserSchema>;
+
+const gongResponseSchema = z.object({
+  users: z.array(z.unknown()),
+  records: z.object({
+    cursor: z.string().optional(),
+  }),
+});
+
+const getUsersResponseData = z.object({
+  user: z.object({ html_url: z.string(), role: z.string() }),
+});
+
+export type GetUsersParams = {
+  userName: string;
+  password: string;
+  page?: string | null;
+};
+
+export const getUsers = async ({ userName, password, page }: GetUsersParams) => {
+  const url = new URL(`${env.GONG_API_BASE_URL}/v2/users`);
+
+  const encodedToken = btoa(`${userName}:${password}`);
+
+  if (page) {
+    url.searchParams.append('cursor', page);
+  }
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Basic ${encodedToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new GongError('Could not retrieve users', { response });
+  }
+
+  const resData: unknown = await response.json();
+
+  const { users, records } = gongResponseSchema.parse(resData);
+
+  const validUsers: GongUser[] = [];
+  const invalidUsers: unknown[] = [];
+
+  for (const user of users) {
+    const userResult = gongUserSchema.safeParse(user);
+    if (userResult.success) {
+      validUsers.push(userResult.data);
+    } else {
+      invalidUsers.push(user);
+    }
+  }
+
+  return {
+    validUsers,
+    invalidUsers,
+    nextPage: records.cursor ? records.cursor : null,
+  };
+};

--- a/apps/gong/src/connectors/gong/users.ts
+++ b/apps/gong/src/connectors/gong/users.ts
@@ -19,10 +19,6 @@ const gongResponseSchema = z.object({
   }),
 });
 
-const getUsersResponseData = z.object({
-  user: z.object({ html_url: z.string(), role: z.string() }),
-});
-
 export type GetUsersParams = {
   userName: string;
   password: string;

--- a/apps/gong/src/inngest/client.ts
+++ b/apps/gong/src/inngest/client.ts
@@ -1,0 +1,36 @@
+import { EventSchemas, Inngest } from 'inngest';
+import { logger } from '@elba-security/logger';
+import { type ConnectionErrorType } from '@elba-security/sdk';
+import { rateLimitMiddleware } from './middlewares/rate-limit-middleware';
+import { elbaConnectionErrorMiddleware } from './middlewares/elba-connection-error-middleware';
+
+export const inngest = new Inngest({
+  id: 'gong',
+  schemas: new EventSchemas().fromRecord<{
+    'gong/users.sync.requested': {
+      data: {
+        organisationId: string;
+        region: string;
+        nangoConnectionId: string;
+        isFirstSync: boolean;
+        syncStartedAt: number;
+        page: string | null;
+      };
+    };
+    'gong/app.installed': {
+      data: {
+        organisationId: string;
+      };
+    };
+    'gong/app.uninstalled': {
+      data: {
+        organisationId: string;
+        region: string;
+        errorType: ConnectionErrorType;
+        errorMetadata?: unknown;
+      };
+    };
+  }>(),
+  middleware: [rateLimitMiddleware, elbaConnectionErrorMiddleware],
+  logger,
+});

--- a/apps/gong/src/inngest/functions/index.ts
+++ b/apps/gong/src/inngest/functions/index.ts
@@ -1,0 +1,5 @@
+import { removeOrganisation } from './organisations/remove-organisation';
+import { syncUsers } from './users/sync-users';
+import { scheduleUsersSync } from './users/schedule-users-sync';
+
+export const inngestFunctions = [removeOrganisation, scheduleUsersSync, syncUsers];

--- a/apps/gong/src/inngest/functions/organisations/remove-organisation.test.ts
+++ b/apps/gong/src/inngest/functions/organisations/remove-organisation.test.ts
@@ -1,0 +1,33 @@
+import { expect, test, describe } from 'vitest';
+import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
+import { env } from '@/common/env';
+import { removeOrganisation } from './remove-organisation';
+
+const region = 'us';
+const organisationId = '00000000-0000-0000-0000-000000000001';
+
+const setup = createInngestFunctionMock(removeOrganisation, 'gong/app.uninstalled');
+
+describe('remove-organisation', () => {
+  test('should remove given organisation', async () => {
+    const elba = spyOnElba();
+
+    const [result] = setup({ organisationId, region, errorType: 'unauthorized' });
+
+    await expect(result).resolves.toBeUndefined();
+
+    expect(elba).toBeCalledTimes(1);
+    expect(elba).toBeCalledWith({
+      organisationId,
+      region,
+      apiKey: env.ELBA_API_KEY,
+      baseUrl: env.ELBA_API_BASE_URL,
+    });
+    const elbaInstance = elba.mock.results.at(0)?.value;
+
+    expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
+    expect(elbaInstance?.connectionStatus.update).toBeCalledWith({
+      errorType: 'unauthorized',
+    });
+  });
+});

--- a/apps/gong/src/inngest/functions/organisations/remove-organisation.ts
+++ b/apps/gong/src/inngest/functions/organisations/remove-organisation.ts
@@ -1,0 +1,28 @@
+import { createElbaOrganisationClient } from '@/connectors/elba/client';
+import { inngest } from '@/inngest/client';
+
+export const removeOrganisation = inngest.createFunction(
+  {
+    id: 'gong-remove-organisation',
+    retries: 5,
+    cancelOn: [
+      {
+        event: 'gong/app.installed',
+        match: 'data.organisationId',
+      },
+    ],
+  },
+  {
+    event: 'gong/app.uninstalled',
+  },
+  async ({ event }) => {
+    const { organisationId, region, errorType, errorMetadata } = event.data;
+
+    const elba = createElbaOrganisationClient({
+      organisationId,
+      region,
+    });
+
+    await elba.connectionStatus.update({ errorType, errorMetadata });
+  }
+);

--- a/apps/gong/src/inngest/functions/users/schedule-users-sync.test.ts
+++ b/apps/gong/src/inngest/functions/users/schedule-users-sync.test.ts
@@ -1,0 +1,129 @@
+import { expect, test, describe, beforeAll, vi, afterAll } from 'vitest';
+import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
+import { NonRetriableError } from 'inngest';
+import { scheduleUsersSync } from './schedule-users-sync';
+
+const now = Date.now();
+
+const setup = createInngestFunctionMock(scheduleUsersSync);
+
+describe('schedule-users-syncs', () => {
+  beforeAll(() => {
+    vi.setSystemTime(now);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  test('should not schedule any jobs when there are no organisations', async () => {
+    const elba = spyOnElba();
+    elba.mockImplementation(() => ({
+      // @ts-expect-error -- this is a mock
+      organisations: {
+        list: vi.fn().mockResolvedValue({ organisations: [] }),
+      },
+    }));
+    const [result, { step }] = setup();
+
+    await expect(result).resolves.toStrictEqual({ organisations: [] });
+    expect(step.sendEvent).toBeCalledTimes(0);
+  });
+
+  test('should schedule jobs when there are organisations', async () => {
+    const elba = spyOnElba();
+    const regionOrganisations = new Map(
+      ['eu', 'us'].map((region) => [
+        region,
+        [{ id: `organisation-id-${region}`, nangoConnectionId: `nango-connection-id-${region}` }],
+      ])
+    );
+    elba.mockImplementation(({ region }) => ({
+      // @ts-expect-error -- this is a mock
+      organisations: {
+        list: vi.fn().mockResolvedValue({
+          organisations: regionOrganisations.get(region) || [],
+        }),
+      },
+    }));
+
+    const [result, { step }] = setup();
+
+    await expect(result).resolves.toStrictEqual({
+      organisations: [...regionOrganisations].flatMap(([region, organisations]) =>
+        organisations.map((organisation) => ({
+          organisationId: organisation.id,
+          nangoConnectionId: organisation.nangoConnectionId,
+          region,
+        }))
+      ),
+    });
+
+    expect(step.sendEvent).toBeCalledTimes(1);
+    expect(step.sendEvent).toBeCalledWith(
+      'sync-users',
+      [...regionOrganisations].flatMap(([region, organisations]) =>
+        organisations.map(({ id: organisationId, nangoConnectionId }) => ({
+          name: 'gong/users.sync.requested',
+          data: {
+            region,
+            organisationId,
+            nangoConnectionId,
+            syncStartedAt: now,
+            isFirstSync: false,
+            page: null,
+          },
+        }))
+      )
+    );
+  });
+
+  test('should schedule jobs and throw an error when there organisation nango connection id is missing', async () => {
+    const elba = spyOnElba();
+    const regionOrganisations = new Map(
+      ['eu', 'us'].map((region) => [
+        region,
+        [
+          {
+            id: `organisation-id-${region}`,
+            nangoConnectionId: region === 'us' ? null : `nango-connection-id-${region}`,
+          },
+        ],
+      ])
+    );
+    elba.mockImplementation(({ region }) => ({
+      // @ts-expect-error -- this is a mock
+      organisations: {
+        list: vi.fn().mockResolvedValue({
+          organisations: regionOrganisations.get(region) || [],
+        }),
+      },
+    }));
+
+    const [result, { step }] = setup();
+
+    await expect(result).rejects.toStrictEqual(
+      new NonRetriableError('Failed to schedule users sync due to missing nango connection ID')
+    );
+
+    expect(step.sendEvent).toBeCalledTimes(1);
+    expect(step.sendEvent).toBeCalledWith(
+      'sync-users',
+      [...regionOrganisations]
+        .filter(([region]) => region !== 'us')
+        .flatMap(([region, organisations]) =>
+          organisations.map(({ id: organisationId, nangoConnectionId }) => ({
+            name: 'gong/users.sync.requested',
+            data: {
+              region,
+              organisationId,
+              nangoConnectionId,
+              syncStartedAt: now,
+              isFirstSync: false,
+              page: null,
+            },
+          }))
+        )
+    );
+  });
+});

--- a/apps/gong/src/inngest/functions/users/schedule-users-sync.ts
+++ b/apps/gong/src/inngest/functions/users/schedule-users-sync.ts
@@ -1,0 +1,71 @@
+import { elbaRegions } from '@elba-security/sdk';
+import { logger } from '@elba-security/logger';
+import { NonRetriableError } from 'inngest';
+import { env } from '@/common/env';
+import { createElbaGlobalClient } from '@/connectors/elba/client';
+import { inngest } from '../../client';
+
+export const scheduleUsersSync = inngest.createFunction(
+  {
+    id: 'gong-schedule-users-syncs',
+    retries: 5,
+  },
+  { cron: env.GONG_USERS_SYNC_CRON },
+  async ({ step }) => {
+    const regionOrganisations = await Promise.all(
+      elbaRegions.map((region) =>
+        step.run(`get-organisations-${region}`, async () => {
+          const elba = createElbaGlobalClient(region);
+          const result = await elba.organisations.list();
+          return result.organisations.map(({ id: organisationId, nangoConnectionId }) => ({
+            organisationId,
+            nangoConnectionId,
+            region,
+          }));
+        })
+      )
+    );
+
+    const invalidOrganisations: { organisationId: string; region: string }[] = [];
+    const organisations: {
+      organisationId: string;
+      region: string;
+      nangoConnectionId: string;
+    }[] = [];
+    for (const { organisationId, region, nangoConnectionId } of regionOrganisations.flat()) {
+      if (!nangoConnectionId) {
+        invalidOrganisations.push({ organisationId, region });
+      } else {
+        organisations.push({ organisationId, region, nangoConnectionId });
+      }
+    }
+
+    if (organisations.length) {
+      await step.sendEvent(
+        'sync-users',
+        organisations.map(({ organisationId, nangoConnectionId, region }) => ({
+          name: 'gong/users.sync.requested',
+          data: {
+            isFirstSync: false,
+            organisationId,
+            nangoConnectionId,
+            region,
+            syncStartedAt: Date.now(),
+            page: null,
+          },
+        }))
+      );
+    }
+
+    if (invalidOrganisations.length) {
+      logger.error('Failed to schedule users sync due to missing nango connection ID', {
+        invalidOrganisations,
+      });
+      throw new NonRetriableError(
+        'Failed to schedule users sync due to missing nango connection ID'
+      );
+    }
+
+    return { organisations };
+  }
+);

--- a/apps/gong/src/inngest/functions/users/sync-users.test.ts
+++ b/apps/gong/src/inngest/functions/users/sync-users.test.ts
@@ -7,15 +7,17 @@ import { syncUsers } from './sync-users';
 const organisationId = '00000000-0000-0000-0000-000000000001';
 const region = 'us';
 const nangoConnectionId = 'nango-connection-id';
+const userName = 'username-1234';
+const password = 'password-1234';
 
 const syncStartedAt = Date.now();
 
 const users: usersConnector.GongUser[] = Array.from({ length: 2 }, (_, i) => ({
   id: `id-${i}`,
-  name: `userName-${i}`,
-  role: 'admin',
-  email: `user-${i}@foo.bar`,
-  invitation_sent: false,
+  firstName: `firstName-${i}`,
+  lastName: `lastName-${i}`,
+  emailAddress: `user-${i}@foo.bar`,
+  active: false,
 }));
 
 const setup = createInngestFunctionMock(syncUsers, 'gong/users.sync.requested');
@@ -25,16 +27,14 @@ describe('sync-users', () => {
     // @ts-expect-error -- this is a mock
     vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
       getConnection: vi.fn().mockResolvedValue({
-        credentials: { access_token: 'access-token' },
+        credentials: { username: userName, password },
       }),
     });
-    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
-      authUserUrl: 'https://test-domain.gong.com',
-    });
+    
     vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
       validUsers: users,
       invalidUsers: [],
-      nextPage: 1,
+      nextPage: 'next-page-cursor',
     });
 
     const [result, { step }] = setup({
@@ -43,7 +43,7 @@ describe('sync-users', () => {
       nangoConnectionId,
       isFirstSync: false,
       syncStartedAt,
-      page: '1',
+      page: 'next-page-cursor',
     });
 
     await expect(result).resolves.toStrictEqual({ status: 'ongoing' });
@@ -57,7 +57,7 @@ describe('sync-users', () => {
         nangoConnectionId,
         isFirstSync: false,
         syncStartedAt,
-        page: '1',
+        page: 'next-page-cursor',
       },
     });
   });
@@ -66,12 +66,10 @@ describe('sync-users', () => {
     // @ts-expect-error -- this is a mock
     vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
       getConnection: vi.fn().mockResolvedValue({
-        credentials: { access_token: 'access-token' },
+        credentials: { username: userName, password },
       }),
     });
-    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
-      authUserUrl: 'https://test-domain.gong.com',
-    });
+    
     vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
       validUsers: users,
       invalidUsers: [],

--- a/apps/gong/src/inngest/functions/users/sync-users.test.ts
+++ b/apps/gong/src/inngest/functions/users/sync-users.test.ts
@@ -1,0 +1,94 @@
+import { expect, test, describe, vi } from 'vitest';
+import { createInngestFunctionMock } from '@elba-security/test-utils';
+import * as usersConnector from '@/connectors/gong/users';
+import * as nangoAPI from '@/common/nango';
+import { syncUsers } from './sync-users';
+
+const organisationId = '00000000-0000-0000-0000-000000000001';
+const region = 'us';
+const nangoConnectionId = 'nango-connection-id';
+
+const syncStartedAt = Date.now();
+
+const users: usersConnector.GongUser[] = Array.from({ length: 2 }, (_, i) => ({
+  id: `id-${i}`,
+  name: `userName-${i}`,
+  role: 'admin',
+  email: `user-${i}@foo.bar`,
+  invitation_sent: false,
+}));
+
+const setup = createInngestFunctionMock(syncUsers, 'gong/users.sync.requested');
+
+describe('sync-users', () => {
+  test('should continue the sync when there is a next page', async () => {
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
+      getConnection: vi.fn().mockResolvedValue({
+        credentials: { access_token: 'access-token' },
+      }),
+    });
+    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
+      authUserUrl: 'https://test-domain.gong.com',
+    });
+    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
+      validUsers: users,
+      invalidUsers: [],
+      nextPage: 1,
+    });
+
+    const [result, { step }] = setup({
+      organisationId,
+      region,
+      nangoConnectionId,
+      isFirstSync: false,
+      syncStartedAt,
+      page: '1',
+    });
+
+    await expect(result).resolves.toStrictEqual({ status: 'ongoing' });
+
+    expect(step.sendEvent).toBeCalledTimes(1);
+    expect(step.sendEvent).toBeCalledWith('sync-users', {
+      name: 'gong/users.sync.requested',
+      data: {
+        organisationId,
+        region,
+        nangoConnectionId,
+        isFirstSync: false,
+        syncStartedAt,
+        page: '1',
+      },
+    });
+  });
+
+  test('should finalize the sync when there is a no next page', async () => {
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(nangoAPI, 'nangoAPIClient', 'get').mockReturnValue({
+      getConnection: vi.fn().mockResolvedValue({
+        credentials: { access_token: 'access-token' },
+      }),
+    });
+    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
+      authUserUrl: 'https://test-domain.gong.com',
+    });
+    vi.spyOn(usersConnector, 'getUsers').mockResolvedValue({
+      validUsers: users,
+      invalidUsers: [],
+      nextPage: null,
+    });
+
+    const [result, { step }] = setup({
+      region,
+      organisationId,
+      nangoConnectionId,
+      isFirstSync: false,
+      syncStartedAt,
+      page: null,
+    });
+
+    await expect(result).resolves.toStrictEqual({ status: 'completed' });
+
+    expect(step.sendEvent).toBeCalledTimes(0);
+  });
+});

--- a/apps/gong/src/inngest/functions/users/sync-users.ts
+++ b/apps/gong/src/inngest/functions/users/sync-users.ts
@@ -1,0 +1,109 @@
+import type { User } from '@elba-security/sdk';
+import { logger } from '@elba-security/logger';
+import { inngest } from '@/inngest/client';
+import { nangoCredentialsSchema } from '@/connectors/common/nango';
+import { getUsers } from '@/connectors/gong/users';
+import { createElbaOrganisationClient } from '@/connectors/elba/client';
+import { type GongUser } from '@/connectors/gong/users';
+import { nangoAPIClient } from '@/common/nango';
+
+const formatElbaUserDisplayName = (user: GongUser) => {
+  if (user.firstName && user.lastName) {
+    return `${user.firstName} ${user.lastName}`;
+  }
+  return user.emailAddress;
+};
+
+const formatElbaUser = ({ user }: { user: GongUser; }): User => ({
+  id: user.id,
+  displayName: formatElbaUserDisplayName(user),
+  email: user.emailAddress,
+  additionalEmails: [],
+  url: `https://app.gong.io/company/team-members`,
+});
+
+export const syncUsers = inngest.createFunction(
+  {
+    id: 'gong-sync-users',
+    priority: {
+      run: 'event.data.isFirstSync ? 600 : 0',
+    },
+    concurrency: {
+      key: 'event.data.organisationId',
+      limit: 1,
+    },
+    cancelOn: [
+      {
+        event: 'gong/app.installed',
+        match: 'data.organisationId',
+      },
+      {
+        event: 'gong/app.uninstalled',
+        match: 'data.organisationId',
+      },
+    ],
+    retries: 5,
+  },
+  { event: 'gong/users.sync.requested' },
+  async ({ event, step }) => {
+    const { organisationId, nangoConnectionId, region, syncStartedAt, page } = event.data;
+
+    const elba = createElbaOrganisationClient({
+      organisationId,
+      region,
+    });
+
+    const nextPage = await step.run('list-users', async () => {
+      const { credentials } = await nangoAPIClient.getConnection(nangoConnectionId);
+
+    const nangoCredentialsResult = nangoCredentialsSchema.safeParse(credentials);
+
+    if (!nangoCredentialsResult.success) {
+      throw new Error('Could not retrieve Nango credentials');
+    }
+      const result = await getUsers({
+        userName: nangoCredentialsResult.data.username,
+        password: nangoCredentialsResult.data.password,
+        page,
+      });
+
+      const users = result.validUsers
+        .filter(({ active }) => active)
+        .map((user) => formatElbaUser({ user }));
+
+      if (result.invalidUsers.length > 0) {
+        logger.warn('Retrieved users contains invalid data', {
+          organisationId,
+          invalidUsers: result.invalidUsers,
+        });
+      }
+
+      if (users.length > 0) {
+        await elba.users.update({ users });
+      }
+
+      return result.nextPage;
+    });
+
+    if (nextPage) {
+      await step.sendEvent('sync-users', {
+        name: 'gong/users.sync.requested',
+        data: {
+          ...event.data,
+          page: String(nextPage),
+        },
+      });
+      return {
+        status: 'ongoing',
+      };
+    }
+
+    await step.run('finalize', () =>
+      elba.users.delete({ syncedBefore: new Date(syncStartedAt).toISOString() })
+    );
+
+    return {
+      status: 'completed',
+    };
+  }
+);

--- a/apps/gong/src/inngest/middlewares/elba-connection-error-middleware.ts
+++ b/apps/gong/src/inngest/middlewares/elba-connection-error-middleware.ts
@@ -1,0 +1,7 @@
+import { createElbaConnectionErrorMiddleware } from '@elba-security/inngest';
+import { mapElbaConnectionError } from '@/connectors/common/error';
+
+export const elbaConnectionErrorMiddleware = createElbaConnectionErrorMiddleware({
+  mapErrorFn: mapElbaConnectionError,
+  eventName: 'gong/app.uninstalled',
+});

--- a/apps/gong/src/inngest/middlewares/rate-limit-middleware.test.ts
+++ b/apps/gong/src/inngest/middlewares/rate-limit-middleware.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+import { RetryAfterError } from 'inngest';
+import { GongError } from '@/connectors/common/error';
+import { rateLimitMiddleware } from './rate-limit-middleware';
+
+describe('rate-limit middleware', () => {
+  test('should not transform the output when their is no error', () => {
+    expect(
+      rateLimitMiddleware
+        .init()
+        // @ts-expect-error -- this is a mock
+        .onFunctionRun({ fn: { name: 'foo' } })
+        .transformOutput({
+          result: {},
+        })
+    ).toBeUndefined();
+  });
+
+  test('should not transform the output when the error is not about Gong rate limit', () => {
+    expect(
+      rateLimitMiddleware
+        .init()
+        // @ts-expect-error -- this is a mock
+        .onFunctionRun({ fn: { name: 'foo' } })
+        .transformOutput({
+          result: {
+            error: new Error('foo bar'),
+          },
+        })
+    ).toBeUndefined();
+  });
+
+  test('should transform the output error to RetryAfterError when the error is about Gong rate limit', () => {
+    const rateLimitError = new GongError('foo bar', {
+      // @ts-expect-error this is a mock
+      response: {
+        status: 429,
+        headers: new Headers({ 'Retry-After': '60' }),
+      },
+    });
+
+    const context = {
+      foo: 'bar',
+      baz: {
+        biz: true,
+      },
+      result: {
+        data: 'bizz',
+        error: rateLimitError,
+      },
+    };
+
+    const result = rateLimitMiddleware
+      .init()
+      // @ts-expect-error -- this is a mock
+      .onFunctionRun({ fn: { name: 'foo' } })
+      .transformOutput(context);
+    expect(result?.result.error).toBeInstanceOf(RetryAfterError);
+    expect(result?.result.error.retryAfter).toStrictEqual('60');
+    expect(result).toMatchObject({
+      foo: 'bar',
+      baz: {
+        biz: true,
+      },
+      result: {
+        data: 'bizz',
+      },
+    });
+  });
+});

--- a/apps/gong/src/inngest/middlewares/rate-limit-middleware.ts
+++ b/apps/gong/src/inngest/middlewares/rate-limit-middleware.ts
@@ -1,0 +1,45 @@
+import { InngestMiddleware, RetryAfterError } from 'inngest';
+import { GongError } from '@/connectors/common/error';
+
+export const rateLimitMiddleware = new InngestMiddleware({
+  name: 'rate-limit',
+  init: () => {
+    return {
+      onFunctionRun: ({ fn }) => {
+        return {
+          transformOutput: (ctx) => {
+            const {
+              result: { error, ...result },
+              ...context
+            } = ctx;
+
+            if (!(error instanceof GongError)) {
+              return;
+            }
+
+            if (error.response?.status === 429) {
+              let retryAfter = 60;
+              const retryAfterHeader = error.response.headers.get('Retry-After');
+              if (retryAfterHeader) {
+                retryAfter = parseInt(retryAfterHeader, 10);
+              }
+              return {
+                ...context,
+                result: {
+                  ...result,
+                  error: new RetryAfterError(
+                    `Rate limit exceeded for '${fn.name}'. Retry after ${retryAfter} seconds.`,
+                    `${retryAfter}s`,
+                    {
+                      cause: error,
+                    }
+                  ),
+                },
+              };
+            }
+          },
+        };
+      },
+    };
+  },
+});

--- a/apps/gong/src/middleware.ts
+++ b/apps/gong/src/middleware.ts
@@ -1,0 +1,8 @@
+import { createElbaMiddleware } from '@elba-security/nextjs';
+import { env } from '@/common/env';
+
+export const middleware = createElbaMiddleware({
+  webhookSecret: env.ELBA_WEBHOOK_SECRET,
+});
+
+export const config = { matcher: ['/api/webhooks/elba/(.*)'] };

--- a/apps/gong/tsconfig.json
+++ b/apps/gong/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@elba-security/tsconfig/nextjs.json",
+  "compilerOptions": {
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "allowJs": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/gong/vercel.json
+++ b/apps/gong/vercel.json
@@ -1,0 +1,8 @@
+{
+  "ignoreCommand": "npx turbo-ignore --fallback=HEAD^1",
+  "functions": {
+    "src/app/api/**/*": {
+      "maxDuration": 60
+    }
+  }
+}

--- a/apps/gong/vitest.config.mts
+++ b/apps/gong/vitest.config.mts
@@ -1,0 +1,31 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+import { config } from 'dotenv';
+import type { BuiltinEnvironment } from 'vitest';
+
+const { error } = config({ path: '.env.test' });
+
+if (error) {
+  throw new Error(`Could not find environment variables file: .env.test`);
+}
+
+const environment: BuiltinEnvironment = 'edge-runtime';
+
+process.env.VITEST_ENVIRONMENT = environment;
+
+export default defineConfig({
+  test: {
+    setupFiles: ['@elba-security/test-utils/vitest/setup-msw-handlers'],
+    environment,
+    poolOptions: {
+      threads: {
+        singleThread: true,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2012,6 +2012,82 @@ importers:
         specifier: 'catalog:'
         version: 1.6.0(@edge-runtime/vm@3.2.0)(@types/node@20.14.2)
 
+  apps/gong:
+    dependencies:
+      '@elba-security/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@elba-security/inngest':
+        specifier: workspace:*
+        version: link:../../packages/inngest
+      '@elba-security/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      '@elba-security/nango':
+        specifier: workspace:*
+        version: link:../../packages/nango
+      '@elba-security/nextjs':
+        specifier: workspace:*
+        version: link:../../packages/nextjs
+      '@elba-security/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      inngest:
+        specifier: 'catalog:'
+        version: 3.25.1(@sveltejs/kit@2.5.10(@sveltejs/vite-plugin-svelte@3.1.2(svelte@5.23.0)(vite@5.3.2(@types/node@20.14.2)))(svelte@5.23.0)(vite@5.3.2(@types/node@20.14.2)))(@vercel/node@2.15.10)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.27.0)(h3@1.9.0)(hono@4.4.10)(koa@2.15.3)(next@14.2.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.5.3)
+      next:
+        specifier: 'catalog:'
+        version: 14.2.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react:
+        specifier: 'catalog:'
+        version: 18.2.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
+    devDependencies:
+      '@edge-runtime/vm':
+        specifier: 'catalog:'
+        version: 3.2.0
+      '@elba-security/eslint-config-custom':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config-custom
+      '@elba-security/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
+      '@elba-security/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@next/eslint-plugin-next':
+        specifier: 'catalog:'
+        version: 14.2.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.14.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.2.79
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.2.25
+      dotenv:
+        specifier: 'catalog:'
+        version: 16.4.5
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.3.1(typescript@5.5.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.5.3
+      vitest:
+        specifier: 'catalog:'
+        version: 1.6.0(@edge-runtime/vm@3.2.0)(@types/node@20.14.2)
+
   apps/google:
     dependencies:
       '@elba-security/config':


### PR DESCRIPTION
## Description

Gong Integration

1. The Gong users endpoint does not support a pageSize parameter to control the number of items returned per request. Instead, it employs cursor-based pagination with a fixed page size of up to 100 records per response
2. It doesn't support user deletion feature

## Additional Notes

N/A

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
