### PR TITLE
feat: add Figma SCIM integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Uses Inngest for async event processing. Two patterns exist:
    - Single `ElbaInngestClient` instance in `inngest/client.ts`
    - All functions created via client methods
    - Single route handler in `app/api/inngest/route.ts`
+   - **NO `ELBA_API_BASE_URL` needed** - uses event-based communication
    - See `INTEGRATION_REFACTORING_CHECKLIST.md` for migration guide
 
 #### File Organization

--- a/apps/figma-scim/.env.local.example
+++ b/apps/figma-scim/.env.local.example
@@ -1,0 +1,11 @@
+# Elba
+ELBA_SOURCE_ID="0442f541-45d2-487a-9e4b-de03ce4c559e"
+
+# Nango
+NANGO_SECRET_KEY="test-nango-secret"
+NANGO_INTEGRATION_ID="figma-scim-sandbox"
+
+# Source Configuration
+FIGMA_SCIM_API_BASE_URL="https://www.figma.com"
+FIGMA_SCIM_USERS_SYNC_CRON="0 0 * * *"
+FIGMA_SCIM_USERS_SYNC_BATCH_SIZE=100

--- a/apps/figma-scim/.env.test
+++ b/apps/figma-scim/.env.test
@@ -1,0 +1,11 @@
+# Elba
+ELBA_SOURCE_ID="0442f541-45d2-487a-9e4b-de03ce4c559e"
+
+# Nango
+NANGO_SECRET_KEY="test-nango-secret"
+NANGO_INTEGRATION_ID="figma-scim-sandbox"
+
+# Source Configuration
+FIGMA_SCIM_API_BASE_URL="https://www.figma.com"
+FIGMA_SCIM_USERS_SYNC_CRON="0 0 * * *"
+FIGMA_SCIM_USERS_SYNC_BATCH_SIZE=100

--- a/apps/figma-scim/.eslintrc.js
+++ b/apps/figma-scim/.eslintrc.js
@@ -1,0 +1,17 @@
+const { resolve } = require('node:path');
+
+const project = resolve(__dirname, './tsconfig.json');
+
+module.exports = {
+  extends: ['@elba-security/eslint-config-custom/next'],
+  parserOptions: {
+    project,
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project,
+      },
+    },
+  },
+};

--- a/apps/figma-scim/.gitignore
+++ b/apps/figma-scim/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/figma-scim/README.md
+++ b/apps/figma-scim/README.md
@@ -128,3 +128,5 @@ All requests use Bearer token authentication with the SCIM API token.
 - [Figma SCIM Documentation](https://help.figma.com/hc/en-us/articles/360040449773-Provision-Figma-with-SCIM)
 - [SCIM 2.0 Protocol](https://datatracker.ietf.org/doc/html/rfc7644)
 - [Nango Figma SCIM Integration](https://docs.nango.dev/integrations/all/figma-scim)
+
+DUMMY

--- a/apps/figma-scim/README.md
+++ b/apps/figma-scim/README.md
@@ -22,7 +22,6 @@ This integration enables Elba Security to manage Figma organization users throug
 ```bash
 # Elba Configuration
 ELBA_SOURCE_ID=                    # Your Elba source ID
-ELBA_API_BASE_URL=                 # Elba API base URL
 
 # Nango Configuration
 NANGO_INTEGRATION_ID=figma-scim   # Nango integration ID

--- a/apps/figma-scim/README.md
+++ b/apps/figma-scim/README.md
@@ -1,0 +1,131 @@
+# Figma SCIM Integration
+
+This integration enables Elba Security to manage Figma organization users through the SCIM 2.0 API.
+
+## Features
+
+- **User Synchronization**: Syncs all active users from your Figma organization
+- **User Deletion**: Deactivates users in Figma when requested by Elba
+- **SCIM 2.0 Compliant**: Uses standard SCIM protocol for user management
+- **Enterprise Ready**: Supports Figma Organization and Enterprise plans
+
+## Prerequisites
+
+- Figma Organization or Enterprise plan
+- Organization admin access
+- SCIM API token from Figma
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Elba Configuration
+ELBA_SOURCE_ID=                    # Your Elba source ID
+ELBA_API_BASE_URL=                 # Elba API base URL
+
+# Nango Configuration
+NANGO_INTEGRATION_ID=figma-scim   # Nango integration ID
+NANGO_SECRET_KEY=                  # Your Nango secret key
+
+# Figma Configuration
+FIGMA_SCIM_API_BASE_URL=https://www.figma.com  # Figma API base URL
+FIGMA_SCIM_USERS_SYNC_CRON="0 0 * * *"         # Daily sync at midnight
+FIGMA_SCIM_USERS_SYNC_BATCH_SIZE=100           # Users per page
+```
+
+### Nango Connection Configuration
+
+When setting up the connection in Nango, you'll need:
+
+1. **API Key**: Generate from Figma Admin Settings → Settings → Login and provisioning → SCIM provisioning
+2. **Tenant ID**: Your Figma organization ID (found in the SCIM settings URL)
+
+The connection config should include:
+
+```json
+{
+  "tenantId": "your-organization-id"
+}
+```
+
+## Development
+
+### Setup
+
+1. Copy `.env.local.example` to `.env.local` and fill in the required values
+2. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+3. Start the development server:
+   ```bash
+   pnpm dev
+   ```
+
+### Testing
+
+Run the test suite:
+
+```bash
+pnpm test
+```
+
+Run linting:
+
+```bash
+pnpm lint
+```
+
+Run type checking:
+
+```bash
+pnpm type-check
+```
+
+## API Implementation
+
+### User Sync
+
+The integration fetches users from Figma's SCIM API and transforms them to Elba's user format:
+
+- Only syncs active users
+- Uses SCIM pagination (startIndex/itemsPerPage)
+- Maps SCIM user attributes to Elba user properties
+
+### User Deletion
+
+When Elba requests user deletion:
+
+- Uses SCIM PATCH operation to set `active: false`
+- Gracefully handles already-deleted users (404 responses)
+
+## SCIM API Details
+
+### Endpoints Used
+
+- `GET /scim/v2/{tenantId}/Users` - List users with pagination
+- `PATCH /scim/v2/{tenantId}/Users/{userId}` - Deactivate users
+
+### Authentication
+
+All requests use Bearer token authentication with the SCIM API token.
+
+### Error Handling
+
+- 401 Unauthorized → Triggers connection error in Elba
+- 404 Not Found (on delete) → Silently succeeds (user already deleted)
+- Other errors → Logged with SCIM error details
+
+## Limitations
+
+- SCIM is only available on Organization and Enterprise plans
+- Can only manage organization members (not guests)
+- Requires organization admin privileges
+- Read-only sync (no user provisioning from Elba)
+
+## Resources
+
+- [Figma SCIM Documentation](https://help.figma.com/hc/en-us/articles/360040449773-Provision-Figma-with-SCIM)
+- [SCIM 2.0 Protocol](https://datatracker.ietf.org/doc/html/rfc7644)
+- [Nango Figma SCIM Integration](https://docs.nango.dev/integrations/all/figma-scim)

--- a/apps/figma-scim/README.md
+++ b/apps/figma-scim/README.md
@@ -128,5 +128,3 @@ All requests use Bearer token authentication with the SCIM API token.
 - [Figma SCIM Documentation](https://help.figma.com/hc/en-us/articles/360040449773-Provision-Figma-with-SCIM)
 - [SCIM 2.0 Protocol](https://datatracker.ietf.org/doc/html/rfc7644)
 - [Nango Figma SCIM Integration](https://docs.nango.dev/integrations/all/figma-scim)
-
-DUMMY

--- a/apps/figma-scim/next.config.js
+++ b/apps/figma-scim/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const { elbaNextConfig } = require('@elba-security/config/next');
+
+const nextConfig = {
+  ...elbaNextConfig,
+  transpilePackages: ['@elba-security/sdk'],
+};
+
+module.exports = nextConfig;

--- a/apps/figma-scim/package.json
+++ b/apps/figma-scim/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@elba-security/figma-scim",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 4000",
+    "dev:inngest": "inngest-cli dev -u http://localhost:4000/api/inngest",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elba-security/common": "workspace:*",
+    "@elba-security/config": "workspace:*",
+    "@elba-security/inngest": "workspace:*",
+    "@elba-security/logger": "workspace:*",
+    "@elba-security/nextjs": "workspace:*",
+    "@elba-security/utils": "workspace:*",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "catalog:",
+    "@elba-security/eslint-config-custom": "workspace:*",
+    "@elba-security/test-utils": "workspace:*",
+    "@elba-security/tsconfig": "workspace:*",
+    "@next/eslint-plugin-next": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "dotenv": "catalog:",
+    "eslint": "catalog:",
+    "msw": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/figma-scim/src/app/api/inngest/route.ts
+++ b/apps/figma-scim/src/app/api/inngest/route.ts
@@ -1,18 +1,5 @@
 import { elbaInngestClient } from '@/inngest/client';
 
-/**
- * Inngest webhook handler for processing asynchronous events.
- * This endpoint:
- * 1. Receives events from Inngest
- * 2. Routes them to the appropriate function handlers
- * 3. Returns the function execution results
- *
- * Configuration:
- * - Uses Edge runtime for better performance
- * - Enables streaming for longer running functions
- * - Forces dynamic rendering to ensure fresh data
- */
-
 export const preferredRegion = 'iad1';
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';

--- a/apps/figma-scim/src/app/api/inngest/route.ts
+++ b/apps/figma-scim/src/app/api/inngest/route.ts
@@ -1,0 +1,20 @@
+import { elbaInngestClient } from '@/inngest/client';
+
+/**
+ * Inngest webhook handler for processing asynchronous events.
+ * This endpoint:
+ * 1. Receives events from Inngest
+ * 2. Routes them to the appropriate function handlers
+ * 3. Returns the function execution results
+ *
+ * Configuration:
+ * - Uses Edge runtime for better performance
+ * - Enables streaming for longer running functions
+ * - Forces dynamic rendering to ensure fresh data
+ */
+
+export const preferredRegion = 'iad1';
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export const { GET, POST, PUT } = elbaInngestClient.serve();

--- a/apps/figma-scim/src/app/layout.tsx
+++ b/apps/figma-scim/src/app/layout.tsx
@@ -1,0 +1,18 @@
+/**
+ * This file is required by nextjs and has no purpose for now in the integration.
+ * It should not be edited or removed.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: `Elba x figma-scim`,
+  description: 'Elba x figma-scim',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/figma-scim/src/app/page.tsx
+++ b/apps/figma-scim/src/app/page.tsx
@@ -1,0 +1,14 @@
+/**
+ * This file is required by nextjs and has no purpose for now in the integration.
+ * It should not be edited or removed.
+ */
+
+/**
+ * Home page component that displays when accessing the root URL.
+ * This is a placeholder page - in production, users will be redirected
+ * to the Elba dashboard after installation.
+ */
+export default function Home() {
+  const title = `Elba x figma-scim`;
+  return <main>{title}</main>;
+}

--- a/apps/figma-scim/src/common/env.ts
+++ b/apps/figma-scim/src/common/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const zEnvInt = () => z.coerce.number().int().positive();
+
+export const env = z
+  .object({
+    // Elba configuration
+    ELBA_SOURCE_ID: z.string().uuid(),
+
+    // Nango configuration
+    NANGO_INTEGRATION_ID: z.string().min(1),
+    NANGO_SECRET_KEY: z.string().min(1),
+
+    // Source configuration
+    FIGMA_SCIM_API_BASE_URL: z.string().url().default('https://www.figma.com'),
+    FIGMA_SCIM_USERS_SYNC_CRON: z.string().default('0 0 * * *'),
+    FIGMA_SCIM_USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
+  })
+  .parse(process.env);

--- a/apps/figma-scim/src/connectors/figma-scim/users.test.ts
+++ b/apps/figma-scim/src/connectors/figma-scim/users.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http } from 'msw';
+import { server } from '@elba-security/test-utils/vitest/setup-msw-handlers';
+import { IntegrationError, IntegrationConnectionError } from '@elba-security/common';
+import { env } from '@/common/env';
+import { getUsers, deleteUser } from './users';
+
+describe('figma-scim/users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server.resetHandlers();
+  });
+
+  describe('getUsers', () => {
+    it('should fetch users successfully with pagination', async () => {
+      server.use(
+        http.get(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users`, () => {
+          return Response.json({
+            schemas: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            totalResults: 3,
+            startIndex: 1,
+            itemsPerPage: 2,
+            Resources: [
+              {
+                schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                id: 'user-1',
+                userName: 'user1@example.com',
+                displayName: 'User One',
+                name: {
+                  givenName: 'User',
+                  familyName: 'One',
+                  formatted: 'User One',
+                },
+                emails: [
+                  {
+                    value: 'user1@example.com',
+                    primary: true,
+                    type: 'work',
+                  },
+                ],
+                active: true,
+                meta: {
+                  resourceType: 'User',
+                  created: '2023-01-01T00:00:00Z',
+                  lastModified: '2023-01-01T00:00:00Z',
+                },
+              },
+              {
+                schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                id: 'user-2',
+                userName: 'user2@example.com',
+                displayName: 'User Two',
+                emails: [
+                  {
+                    value: 'user2@example.com',
+                    primary: true,
+                  },
+                ],
+                active: true,
+                meta: {
+                  resourceType: 'User',
+                  created: '2023-01-01T00:00:00Z',
+                  lastModified: '2023-01-01T00:00:00Z',
+                },
+              },
+            ],
+          });
+        })
+      );
+
+      const result = await getUsers({
+        apiKey: 'test-api-key',
+        tenantId: 'test-tenant',
+        startIndex: 1,
+        count: 2,
+      });
+
+      expect(result).toEqual({
+        users: [
+          {
+            id: 'user-1',
+            displayName: 'User One',
+            email: 'user1@example.com',
+          },
+          {
+            id: 'user-2',
+            displayName: 'User Two',
+            email: 'user2@example.com',
+          },
+        ],
+        nextStartIndex: 3,
+        totalResults: 3,
+      });
+    });
+
+    it('should handle last page without next cursor', async () => {
+      server.use(
+        http.get(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users`, () => {
+          return Response.json({
+            schemas: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            totalResults: 1,
+            startIndex: 1,
+            itemsPerPage: 100,
+            Resources: [
+              {
+                schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                id: 'user-1',
+                userName: 'user@example.com',
+                active: true,
+              },
+            ],
+          });
+        })
+      );
+
+      const result = await getUsers({
+        apiKey: 'test-api-key',
+        tenantId: 'test-tenant',
+      });
+
+      expect(result.nextStartIndex).toBeUndefined();
+      expect(result.users).toHaveLength(1);
+    });
+
+    it('should filter out inactive users', async () => {
+      server.use(
+        http.get(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users`, () => {
+          return Response.json({
+            schemas: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            totalResults: 2,
+            Resources: [
+              {
+                schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                id: 'user-1',
+                userName: 'active@example.com',
+                active: true,
+              },
+              {
+                schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                id: 'user-2',
+                userName: 'inactive@example.com',
+                active: false,
+              },
+            ],
+          });
+        })
+      );
+
+      const result = await getUsers({
+        apiKey: 'test-api-key',
+        tenantId: 'test-tenant',
+      });
+
+      expect(result.users).toHaveLength(1);
+      expect(result.users[0]?.email).toBe('active@example.com');
+    });
+
+    it('should throw IntegrationConnectionError on 401', async () => {
+      server.use(
+        http.get(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users`, () => {
+          return new Response(null, { status: 401 });
+        })
+      );
+
+      await expect(
+        getUsers({
+          apiKey: 'invalid-key',
+          tenantId: 'test-tenant',
+        })
+      ).rejects.toThrow(IntegrationConnectionError);
+    });
+
+    it('should throw IntegrationError on other errors', async () => {
+      server.use(
+        http.get(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users`, () => {
+          return Response.json(
+            {
+              schemas: ['urn:ietf:params:scim:api:messages:2.0:Error'],
+              detail: 'Internal server error',
+              status: '500',
+            },
+            { status: 500 }
+          );
+        })
+      );
+
+      await expect(
+        getUsers({
+          apiKey: 'test-key',
+          tenantId: 'test-tenant',
+        })
+      ).rejects.toThrow(IntegrationError);
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('should deactivate user successfully', async () => {
+      server.use(
+        http.patch(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users/user-1`, () => {
+          return new Response(null, { status: 200 });
+        })
+      );
+
+      await expect(
+        deleteUser({
+          apiKey: 'test-api-key',
+          tenantId: 'test-tenant',
+          userId: 'user-1',
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('should not throw on 404 (user already deleted)', async () => {
+      server.use(
+        http.patch(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users/user-1`, () => {
+          return new Response(null, { status: 404 });
+        })
+      );
+
+      await expect(
+        deleteUser({
+          apiKey: 'test-api-key',
+          tenantId: 'test-tenant',
+          userId: 'user-1',
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw IntegrationConnectionError on 401', async () => {
+      server.use(
+        http.patch(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users/user-1`, () => {
+          return new Response(null, { status: 401 });
+        })
+      );
+
+      await expect(
+        deleteUser({
+          apiKey: 'invalid-key',
+          tenantId: 'test-tenant',
+          userId: 'user-1',
+        })
+      ).rejects.toThrow(IntegrationConnectionError);
+    });
+
+    it('should throw IntegrationError on other errors', async () => {
+      server.use(
+        http.patch(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/test-tenant/Users/user-1`, () => {
+          return Response.json(
+            {
+              schemas: ['urn:ietf:params:scim:api:messages:2.0:Error'],
+              detail: 'Bad request',
+              status: '400',
+            },
+            { status: 400 }
+          );
+        })
+      );
+
+      await expect(
+        deleteUser({
+          apiKey: 'test-key',
+          tenantId: 'test-tenant',
+          userId: 'user-1',
+        })
+      ).rejects.toThrow(IntegrationError);
+    });
+  });
+});

--- a/apps/figma-scim/src/connectors/figma-scim/users.ts
+++ b/apps/figma-scim/src/connectors/figma-scim/users.ts
@@ -1,0 +1,170 @@
+import { z } from 'zod';
+import { IntegrationError, IntegrationConnectionError } from '@elba-security/common';
+import { env } from '@/common/env';
+
+// SCIM User Schema based on RFC 7643
+const scimUserSchema = z.object({
+  schemas: z.array(z.string()),
+  id: z.string(),
+  userName: z.string(),
+  name: z
+    .object({
+      givenName: z.string().optional(),
+      familyName: z.string().optional(),
+      formatted: z.string().optional(),
+    })
+    .optional(),
+  displayName: z.string().optional(),
+  emails: z
+    .array(
+      z.object({
+        value: z.string().email(),
+        primary: z.boolean().optional(),
+        type: z.string().optional(),
+      })
+    )
+    .optional(),
+  active: z.boolean(),
+  meta: z
+    .object({
+      resourceType: z.string(),
+      created: z.string(),
+      lastModified: z.string(),
+      location: z.string().optional(),
+    })
+    .optional(),
+});
+
+// SCIM List Response Schema
+const scimListResponseSchema = z.object({
+  schemas: z.array(z.string()),
+  totalResults: z.number(),
+  startIndex: z.number().optional(),
+  itemsPerPage: z.number().optional(),
+  Resources: z.array(scimUserSchema),
+});
+
+// SCIM Error Response Schema
+const scimErrorSchema = z.object({
+  schemas: z.array(z.string()),
+  detail: z.string().optional(),
+  status: z.string().optional(),
+  scimType: z.string().optional(),
+});
+
+export type ScimUser = z.infer<typeof scimUserSchema>;
+
+type GetUsersParams = {
+  apiKey: string;
+  tenantId: string;
+  startIndex?: number;
+  count?: number;
+};
+
+/**
+ * Fetches users from Figma SCIM API with pagination support
+ */
+export const getUsers = async ({
+  apiKey,
+  tenantId,
+  startIndex = 1,
+  count = 100,
+}: GetUsersParams) => {
+  const url = new URL(`${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/${tenantId}/Users`);
+
+  // SCIM pagination parameters
+  url.searchParams.append('startIndex', String(startIndex));
+  url.searchParams.append('count', String(count));
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/scim+json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' });
+    }
+
+    const errorData: unknown = await response.json().catch(() => null);
+    const error = errorData ? scimErrorSchema.safeParse(errorData).data : null;
+
+    throw new IntegrationError(`SCIM API error: ${error?.detail || 'Unknown error'}`, {
+      response,
+    });
+  }
+
+  const resData: unknown = await response.json();
+  const result = scimListResponseSchema.parse(resData);
+
+  // Transform SCIM users to Elba format
+  const users = result.Resources.filter((user) => user.active) // Only sync active users
+    .map((user) => ({
+      id: user.id,
+      displayName: user.displayName || user.name?.formatted || user.userName,
+      email: user.emails?.find((e) => e.primary)?.value || user.emails?.[0]?.value || user.userName,
+    }));
+
+  // Calculate next start index for pagination
+  const nextStartIndex =
+    result.totalResults > startIndex + users.length - 1 ? startIndex + count : undefined;
+
+  return {
+    users,
+    nextStartIndex,
+    totalResults: result.totalResults,
+  };
+};
+
+type DeleteUserParams = {
+  apiKey: string;
+  tenantId: string;
+  userId: string;
+};
+
+/**
+ * Deletes (deactivates) a user in Figma via SCIM API
+ */
+export const deleteUser = async ({ apiKey, tenantId, userId }: DeleteUserParams) => {
+  const url = `${env.FIGMA_SCIM_API_BASE_URL}/scim/v2/${tenantId}/Users/${userId}`;
+
+  // SCIM uses PATCH with active: false to deactivate users
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/scim+json',
+    },
+    body: JSON.stringify({
+      schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+      Operations: [
+        {
+          op: 'replace',
+          path: 'active',
+          value: false,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      // User already deleted or doesn't exist - not an error
+      return;
+    }
+
+    if (response.status === 401) {
+      throw new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' });
+    }
+
+    const errorData: unknown = await response.json().catch(() => null);
+    const error = errorData ? scimErrorSchema.safeParse(errorData).data : null;
+
+    throw new IntegrationError(`Failed to deactivate user: ${error?.detail || 'Unknown error'}`, {
+      response,
+    });
+  }
+};

--- a/apps/figma-scim/src/inngest/client.ts
+++ b/apps/figma-scim/src/inngest/client.ts
@@ -1,0 +1,57 @@
+import { ElbaInngestClient } from '@elba-security/inngest';
+import { env } from '@/common/env';
+import { getUsers, deleteUser } from '@/connectors/figma-scim/users';
+
+export const elbaInngestClient = new ElbaInngestClient({
+  name: 'figma-scim',
+  nangoAuthType: 'API_KEY',
+  nangoIntegrationId: env.NANGO_INTEGRATION_ID,
+  nangoSecretKey: env.NANGO_SECRET_KEY,
+  sourceId: env.ELBA_SOURCE_ID,
+});
+
+elbaInngestClient.createElbaUsersSyncSchedulerFn(env.FIGMA_SCIM_USERS_SYNC_CRON);
+
+elbaInngestClient.createElbaUsersSyncFn(async ({ connection, cursor }) => {
+  const result = await getUsers({
+    apiKey: connection.credentials.apiKey,
+    tenantId: connection.connection_config.tenantId as string,
+    startIndex: cursor ? parseInt(cursor) : 1,
+    count: env.FIGMA_SCIM_USERS_SYNC_BATCH_SIZE,
+  });
+
+  return {
+    users: result.users.map((user) => ({
+      id: user.id,
+      displayName: user.displayName,
+      email: user.email,
+      additionalEmails: [],
+      isSuspendable: true,
+      url: `${env.FIGMA_SCIM_API_BASE_URL}/files/team/${
+        connection.connection_config.tenantId as string
+      }/members`,
+    })),
+    cursor: result.nextStartIndex ? String(result.nextStartIndex) : null,
+  };
+});
+
+elbaInngestClient.createElbaUsersDeleteFn({
+  isBatchDeleteSupported: false,
+  deleteUsersFn: async ({ connection, id }) => {
+    await deleteUser({
+      apiKey: connection.credentials.apiKey,
+      tenantId: connection.connection_config.tenantId as string,
+      userId: id,
+    });
+  },
+});
+
+elbaInngestClient.createInstallationValidateFn(async ({ connection }) => {
+  // Validate by trying to fetch users with a small limit
+  await getUsers({
+    apiKey: connection.credentials.apiKey,
+    tenantId: connection.connection_config.tenantId as string,
+    startIndex: 1,
+    count: 1,
+  });
+});

--- a/apps/figma-scim/tsconfig.json
+++ b/apps/figma-scim/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@elba-security/tsconfig/nextjs.json",
+  "compilerOptions": {
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "allowJs": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/figma-scim/vercel.json
+++ b/apps/figma-scim/vercel.json
@@ -1,0 +1,8 @@
+{
+  "ignoreCommand": "npx turbo-ignore --fallback=HEAD^1",
+  "functions": {
+    "src/app/api/**/*": {
+      "maxDuration": 60
+    }
+  }
+}

--- a/apps/figma-scim/vitest.config.mts
+++ b/apps/figma-scim/vitest.config.mts
@@ -1,0 +1,26 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+import { config } from 'dotenv';
+import type { BuiltinEnvironment } from 'vitest';
+
+const { error } = config({ path: '.env.test' });
+
+if (error) {
+  throw new Error(`Could not find environment variables file: .env.test`);
+}
+
+const environment: BuiltinEnvironment = 'edge-runtime';
+
+process.env.VITEST_ENVIRONMENT = environment;
+
+export default defineConfig({
+  test: {
+    setupFiles: ['@elba-security/test-utils/vitest/setup-msw-handlers'],
+    environment,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1866,6 +1866,79 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.14.2)(msw@2.3.1(typescript@5.5.3))
 
+  apps/figma-scim:
+    dependencies:
+      '@elba-security/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@elba-security/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@elba-security/inngest':
+        specifier: workspace:*
+        version: link:../../packages/inngest
+      '@elba-security/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      '@elba-security/nextjs':
+        specifier: workspace:*
+        version: link:../../packages/nextjs
+      '@elba-security/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      next:
+        specifier: 'catalog:'
+        version: 14.2.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react:
+        specifier: 'catalog:'
+        version: 18.2.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
+    devDependencies:
+      '@edge-runtime/vm':
+        specifier: 'catalog:'
+        version: 3.2.0
+      '@elba-security/eslint-config-custom':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config-custom
+      '@elba-security/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
+      '@elba-security/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@next/eslint-plugin-next':
+        specifier: 'catalog:'
+        version: 14.2.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.14.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.2.79
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.2.25
+      dotenv:
+        specifier: 'catalog:'
+        version: 16.4.5
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.3.1(typescript@5.5.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.5.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.1.2(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.14.2)(msw@2.3.1(typescript@5.5.3))
+
   apps/fivetran:
     dependencies:
       '@elba-security/config':

--- a/template/README.md
+++ b/template/README.md
@@ -1,13 +1,13 @@
 # Elba Integration Template
 
-This template provides a foundation for building integrations with Elba Security. It follows the same structure as our production integrations like Bitbucket.
+This template provides a foundation for building integrations with Elba Security using the modern ElbaInngestClient pattern.
 
 ## Features
 
-- **OAuth Authentication**: Pre-configured OAuth flow using [Nango](https://nango.dev/)
-- **Event Handling**: Event-driven architecture using [Inngest](https://www.inngest.com/)
+- **Authentication**: Flexible authentication support via [Nango](https://nango.dev/) (OAuth2, API Key, Basic Auth)
+- **Event-Driven Architecture**: Async event processing using [Inngest](https://www.inngest.com/)
 - **Type Safety**: Full TypeScript support with proper type definitions
-- **Testing**: Ready-to-use testing setup with Vitest
+- **Testing**: Ready-to-use testing setup with Vitest and MSW
 
 ## Getting Started
 
@@ -17,8 +17,8 @@ This template provides a foundation for building integrations with Elba Security
 
    ```
    ELBA_SOURCE_ID=
-   ELBA_WEBHOOK_SECRET=
    NANGO_INTEGRATION_ID=
+   NANGO_SECRET_KEY=
    ```
 
 2. Install dependencies:
@@ -51,116 +51,112 @@ This template provides a foundation for building integrations with Elba Security
 src/
 ├── app/
 │   └── api/
-│       └── webhooks/
-│           └── elba/
-│               └── installation/
-│                   └── validate/
-│                       ├── route.ts    # Installation validation webhook
-│                       └── service.ts  # Installation validation logic
+│       └── inngest/
+│           └── route.ts        # Inngest webhook handler
 ├── common/
-│   └── nango.ts        # Nango client configuration
+│   └── env.ts                  # Environment variable validation
 ├── connectors/
-│   ├── common/
-│   │   └── error.ts    # Error mapping utilities
-│   ├── elba/
-│   │   └── client.ts   # Elba client utilities
-│   └── {{name}}/       # Your integration-specific code
-│       └── users.ts    # Integration-specific API calls and types
+│   └── {{name}}/               # Your integration-specific code
+│       ├── users.ts            # API client implementation
+│       └── users.test.ts       # Tests for API client
 └── inngest/
-    ├── client.ts       # Inngest client configuration
-    └── functions/      # Integration-specific event handlers
-        └── users/      # User synchronization functions
+    └── client.ts               # ElbaInngestClient setup and functions
 ```
 
-## Features
+## Implementation Guide
 
-### Installation Validation
+### 1. Configure Environment Variables
 
-The template includes a webhook-based installation flow that:
+Update `src/common/env.ts` with your integration-specific environment variables:
 
-1. Validates the Nango connection
-2. Verifies access to the source API
-3. Triggers initial sync events
+```typescript
+export const env = z
+  .object({
+    ELBA_SOURCE_ID: z.string().uuid(),
+    NANGO_INTEGRATION_ID: z.string().min(1),
+    NANGO_SECRET_KEY: z.string().min(1),
+    // Add your integration-specific variables here
+    {{NAME}}_API_BASE_URL: z.string().url(),
+    {{NAME}}_USERS_SYNC_CRON: z.string().default('0 0 * * *'),
+    {{NAME}}_USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
+  })
+  .parse(process.env);
+```
+
+### 2. Update Inngest Client
+
+In `src/inngest/client.ts`:
+
+1. Set the appropriate `nangoAuthType` ('OAUTH2', 'API_KEY', or 'BASIC')
+2. Implement the user sync function
+3. Implement the user delete function (if supported)
+4. Implement the installation validation function
+
+### 3. Implement API Connectors
+
+In `src/connectors/{{name}}/users.ts`:
+
+1. Define your API response schemas using Zod
+2. Implement `getUsers()` with pagination support
+3. Implement `deleteUser()` if your API supports it
+4. Add proper error handling using `IntegrationError` and `IntegrationConnectionError`
+
+### 4. Write Tests
+
+Update `src/connectors/{{name}}/users.test.ts` with tests for your API implementation using MSW for mocking.
+
+## Key Patterns
+
+### Authentication
+
+The integration uses Nango for authentication. Users will authenticate through Nango's UI, and your integration receives credentials via the `connection` object:
+
+- OAuth2: `connection.credentials.access_token`
+- API Key: `connection.credentials.apiKey`
+- Basic Auth: `connection.credentials.username` and `connection.credentials.password`
 
 ### Error Handling
 
-Built-in error management features:
-
-- Automatic mapping of common errors (401, 403, etc.)
-- Connection status updates
-- Error logging and serialization
-
-## Development
-
-1. Add your source-specific validation logic in `src/app/api/webhooks/elba/installation/validate/service.ts`
-2. Implement your resource sync handlers
-3. Add any additional webhooks needed for your integration
-
-## Environment Files
-
-The template uses several environment files for different purposes:
-
-- `.env.local.example` → `.env.local`: Development environment variables
-- `.env.test`: Default test values (committed to repo)
-- `.env.test.local`: Local test overrides (git-ignored)
-
-This pattern ensures:
-
-- Consistent test values across the team
-- Easy local development setup
-- Safe local overrides without affecting the repository
-
-## Authentication & Installation Flow
-
-The authentication flow happens entirely in Elba's SaaS platform. Once completed:
-
-1. Elba calls the integration's webhook endpoint `/api/webhooks/elba/installation/validate`
-2. The integration performs additional checks (e.g., verifying admin permissions)
-3. If validation succeeds, initial sync events are triggered
-
-For implementation details, see `src/app/api/webhooks/elba/installation/validate/`.
-
-## Event Types
-
-The template includes the following Inngest events:
+Use the standard error types from `@elba-security/common`:
 
 ```typescript
-'{{name}}/app.installed': {
-  data: {
-    organisationId: string;
-  }
-}
+// For general API errors
+throw new IntegrationError('Error message', { response });
 
-'{{name}}/app.uninstalled': {
-  data: {
-    organisationId: string;
-    region: string;
-    errorType: ConnectionErrorType;
-    errorMetadata?: unknown;
-  }
-}
-
-'{{name}}/users.sync.requested': {
-  data: {
-    organisationId: string;
-    region: string;
-    nangoConnectionId: string;
-    isFirstSync: boolean;
-    syncStartedAt: number;
-    page: string | null;
-  }
-}
+// For authentication/connection errors
+throw new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' });
 ```
 
-## Error Handling
+### Event Processing
 
-The template includes built-in error handling for:
+The ElbaInngestClient handles all event orchestration. You only need to implement:
 
-- OAuth authentication failures
-- Rate limiting (via middleware)
-- Connection errors (unauthorized, not admin)
-- API errors with proper error mapping
+1. **User Sync**: Fetch and transform users to Elba's format
+2. **User Delete**: Remove/deactivate users in your system
+3. **Installation Validation**: Verify the connection works
 
-## Contributing
+## Testing
 
-Please refer to the main repository's [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+Run the test suite:
+
+```bash
+pnpm test        # Run tests once
+pnpm test:watch  # Run tests in watch mode
+```
+
+Run linting and type checking:
+
+```bash
+pnpm lint        # ESLint
+pnpm type-check  # TypeScript compiler
+```
+
+## Deployment
+
+The integration is deployed as a Next.js application. Ensure all environment variables are configured in your deployment platform.
+
+## Resources
+
+- [Elba Documentation](https://docs.elba.io)
+- [Nango Documentation](https://docs.nango.dev)
+- [Inngest Documentation](https://www.inngest.com/docs)

--- a/template/README.md
+++ b/template/README.md
@@ -76,9 +76,9 @@ export const env = z
     NANGO_INTEGRATION_ID: z.string().min(1),
     NANGO_SECRET_KEY: z.string().min(1),
     // Add your integration-specific variables here
-    {{NAME}}_API_BASE_URL: z.string().url(),
-    {{NAME}}_USERS_SYNC_CRON: z.string().default('0 0 * * *'),
-    {{NAME}}_USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
+    {{name}}_API_BASE_URL: z.string().url(),
+    {{name}}_USERS_SYNC_CRON: z.string().default('0 0 * * *'),
+    {{name}}_USERS_SYNC_BATCH_SIZE: zEnvInt().default(100),
   })
   .parse(process.env);
 ```

--- a/template/README.md
+++ b/template/README.md
@@ -16,7 +16,6 @@ This template provides a foundation for building integrations with Elba Security
 1. Copy `.env.local.example` to `.env.local` and fill in the required environment variables:
 
    ```
-   ELBA_API_BASE_URL=
    ELBA_SOURCE_ID=
    ELBA_WEBHOOK_SECRET=
    NANGO_INTEGRATION_ID=


### PR DESCRIPTION
## Summary
- Implement user sync using SCIM 2.0 API for Figma organizations
- Add user deletion (deactivation) functionality using SCIM PATCH operations
- Support for Organization/Enterprise plans only (SCIM requirement)

## Test plan
- [x] Unit tests for SCIM client implementation
- [x] Tests for user sync with pagination
- [x] Tests for user deletion/deactivation
- [x] Error handling tests (401, 404, 500)
- [x] Linting passes
- [x] Type checking passes

## Implementation Details
- Uses `API_KEY` authentication through Nango (not OAuth)
- Requires manual SCIM token generation from Figma admin settings
- Connection config includes `tenantId` for organization identification
- Only syncs active users from Figma
- Gracefully handles already-deleted users (404 responses)

## Configuration Required
1. Generate SCIM API token from Figma Admin Settings
2. Configure Nango connection with:
   - API Key (SCIM token)
   - Connection config with `tenantId`

🤖 Generated with [Claude Code](https://claude.ai/code)