### PR TITLE
fix: handle non-admin users in GitLab auth check

### DIFF
--- a/apps/gitlab/src/connectors/gitlab/users.test.ts
+++ b/apps/gitlab/src/connectors/gitlab/users.test.ts
@@ -156,7 +156,7 @@ describe('users connector', () => {
             avatar_url: null,
             web_url: 'https://gitlab.com/auth-user',
             created_at: '2023-01-01T00:00:00.000Z',
-            is_admin: isAdmin,
+            ...(isAdmin && { is_admin: true }),
           };
           return Response.json(authUser);
         })
@@ -194,7 +194,7 @@ describe('users connector', () => {
             avatar_url: null,
             web_url: 'https://gitlab.com/auth-user',
             created_at: '2023-01-01T00:00:00.000Z',
-            is_admin: false,
+            // is_admin field is omitted for non-admin users
           },
         })
       );

--- a/apps/gitlab/src/connectors/gitlab/users.ts
+++ b/apps/gitlab/src/connectors/gitlab/users.ts
@@ -21,8 +21,9 @@ const gitlabUserSchema = z.object({
 export type GitLabUser = z.infer<typeof gitlabUserSchema>;
 
 // GitLab's response for authenticated user (GET /user)
+// Note: is_admin field is only present for admin users
 const gitlabAuthUserSchema = gitlabUserSchema.extend({
-  is_admin: z.boolean(),
+  is_admin: z.boolean().optional(),
 });
 
 export type GitLabAuthUser = z.infer<typeof gitlabAuthUserSchema>;
@@ -149,7 +150,8 @@ export const getAuthUser = async (accessToken: string) => {
   }
 
   // Check if user has admin privileges
-  if (!userResult.data.is_admin) {
+  // is_admin field is only present for admin users (missing = not admin)
+  if (userResult.data.is_admin !== true) {
     throw new IntegrationConnectionError('User is not admin', {
       type: 'not_admin',
       metadata: userResult.data,


### PR DESCRIPTION
## Summary
Fixes the installation validation error where GitLab's API doesn't return the `is_admin` field for non-admin users.

## Problem
The GitLab `/api/v4/user` endpoint only includes the `is_admin` field when the user is actually an admin. For non-admin users, the field is completely omitted, causing our schema validation to fail with:
```
"expected": "boolean",
"message": "Required",
"path": ["is_admin"],
"received": "undefined"
```

## Solution
- Changed `is_admin` field to optional in the schema
- Updated validation logic to treat missing field as non-admin (`is_admin \!== true`)
- Updated tests to reflect this behavior

## Test Plan
- [x] All tests passing
- [x] Type checking passes
- [x] Linting passes
- [ ] Manual testing with non-admin user
- [ ] Manual testing with admin user