### PR TITLE
fix: align GitLab integration with official API documentation

### DIFF
--- a/apps/gitlab/README.md
+++ b/apps/gitlab/README.md
@@ -84,22 +84,31 @@ GITLAB_USERS_SYNC_BATCH_SIZE= # Number of users per page (default: 100)
 
 ### User Sync
 
-- Fetches all active users from GitLab instance
-- Filters out bot users and inactive users
-- Marks admin users as non-suspendable
-- Supports keyset-based pagination via Link headers
+- Fetches all active users from GitLab instance using `/api/v4/users`
+- Filters out:
+  - Bot users (`bot: true`)
+  - External users (`external: true`)
+  - Non-active users (blocked, deactivated)
+- Admin-only fields (email, is_admin) are only visible when using admin token
+- Marks admin users as non-suspendable when the field is present
+- Supports pagination via Link headers
 
 ### User Deactivation
 
-- Uses GitLab's `/api/v4/users/:id/deactivate` endpoint
+- Uses GitLab's User Moderation API: `/api/v4/users/:id/deactivate`
 - Requires admin privileges
-- Handles cases where user is already deactivated or doesn't exist
+- Returns 201 on successful deactivation
+- Handles multiple error cases:
+  - 404: User not found (treated as success)
+  - 403: Insufficient permissions or user not eligible for deactivation
+  - 401: Invalid access token
 
-### Error Handling
+### API Compliance
 
-- `401 Unauthorized`: Invalid or expired access token
-- `403 Forbidden`: User lacks admin privileges
-- `404 Not Found`: User doesn't exist (treated as success)
+- User schema follows GitLab API v4 specification
+- `is_admin` field only present for admin users (not included for regular users)
+- Proper handling of nullable fields (`avatar_url`, `email`, etc.)
+- Query parameters for filtering: `active=true`, `blocked=false`
 
 ## Testing
 


### PR DESCRIPTION
## Summary
Complete rewrite of GitLab integration to properly match the official API documentation after thorough review.

## Changes Made

### API Compliance
- **User Schema**: Properly reflects actual GitLab API response fields
  - Required fields: `id`, `username`, `name`, `state`, `locked`, `avatar_url`, `web_url`
  - Admin-only fields: `email`, `created_at`, `is_admin` (only visible when requester is admin)
  - Optional fields: `bot`, `external`

### Critical Fix: `is_admin` Field Handling
- **Problem**: The `is_admin` field is only present in the response when the user is actually an admin
- **Solution**: Made `is_admin` optional in schema and check for `\!== true` instead of falsy

### User Filtering
- Added `active=true` and `blocked=false` query parameters
- Additional filtering for bot users (`bot: true`)
- Additional filtering for external users (`external: true`)
- Double-check state is 'active' in validation

### Error Handling Improvements
- Deactivation 403 error now has more descriptive message
- Proper handling of all documented error codes

### Tests Updated
- Reflects actual API behavior
- Tests for admin vs non-admin token responses
- Tests for all filtering scenarios

## Testing
- [x] All tests passing
- [x] Type checking passes
- [x] Linting passes
- [ ] Manual testing with real GitLab instance

## Related Issues
Fixes the installation validation error where non-admin users were failing due to missing `is_admin` field.