### PR TITLE
feat: add Terraform integration

### DIFF
--- a/apps/terraform/.env.local.example
+++ b/apps/terraform/.env.local.example
@@ -1,0 +1,11 @@
+# Elba
+ELBA_SOURCE_ID="0442f541-45d2-487a-9e4b-de03ce4c559e"
+
+# Nango
+NANGO_SECRET_KEY="test-nango-secret"
+NANGO_INTEGRATION_ID="terraform-sandbox"
+
+# Source Configuration
+TERRAFORM_API_BASE_URL="https://api.terraform.io"
+TERRAFORM_USERS_SYNC_CRON="0 0 * * *"
+TERRAFORM_USERS_SYNC_BATCH_SIZE=1

--- a/apps/terraform/.env.test
+++ b/apps/terraform/.env.test
@@ -1,0 +1,11 @@
+# Elba
+ELBA_SOURCE_ID="0442f541-45d2-487a-9e4b-de03ce4c559e"
+
+# Nango
+NANGO_SECRET_KEY="test-nango-secret"
+NANGO_INTEGRATION_ID="terraform-sandbox"
+
+# Source Configuration
+TERRAFORM_API_BASE_URL="https://api.terraform.io"
+TERRAFORM_USERS_SYNC_CRON="0 0 * * *"
+TERRAFORM_USERS_SYNC_BATCH_SIZE=1

--- a/apps/terraform/.eslintrc.js
+++ b/apps/terraform/.eslintrc.js
@@ -1,0 +1,17 @@
+const { resolve } = require('node:path');
+
+const project = resolve(__dirname, './tsconfig.json');
+
+module.exports = {
+  extends: ['@elba-security/eslint-config-custom/next'],
+  parserOptions: {
+    project,
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project,
+      },
+    },
+  },
+};

--- a/apps/terraform/.gitignore
+++ b/apps/terraform/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -1,0 +1,121 @@
+# Terraform Integration for Elba Security
+
+This integration connects Terraform Cloud/Enterprise with Elba Security to provide user management and security capabilities.
+
+## Features
+
+- **User Synchronization**: Syncs organization members from Terraform to Elba
+- **User Management**: Support for removing users from Terraform organizations
+- **Authentication**: OAuth2 authentication via [Nango](https://nango.dev/)
+- **Event-Driven Architecture**: Async event processing using [Inngest](https://www.inngest.com/)
+
+## Getting Started
+
+### Development Setup
+
+1. Copy `.env.local.example` to `.env.local` and fill in the required environment variables:
+
+   ```
+   ELBA_SOURCE_ID=            # Your Elba source ID
+   NANGO_INTEGRATION_ID=      # Your Nango integration ID
+   NANGO_SECRET_KEY=          # Your Nango secret key
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+3. Start the development server:
+   ```bash
+   pnpm dev
+   ```
+
+### Testing Setup
+
+1. The `.env.test` file contains default test values and is committed to the repository
+2. For local test overrides:
+   ```bash
+   cp .env.test .env.test.local
+   ```
+3. Modify `.env.test.local` with your test-specific values (this file is git-ignored)
+4. Run tests:
+   ```bash
+   pnpm test
+   ```
+
+## Project Structure
+
+```
+src/
+├── app/
+│   └── api/
+│       └── inngest/
+│           └── route.ts        # Inngest webhook handler
+├── common/
+│   └── env.ts                  # Environment variable validation
+├── connectors/
+│   └── terraform/
+│       ├── users.ts            # Terraform API client implementation
+│       └── users.test.ts       # Tests for API client
+└── inngest/
+    └── client.ts               # ElbaInngestClient setup and functions
+```
+
+## Implementation Details
+
+### Authentication
+
+The integration uses OAuth2 authentication through Nango. Users authenticate with their Terraform Cloud account, and the integration receives an access token to make API calls.
+
+### User Synchronization
+
+The integration syncs organization members from Terraform to Elba:
+
+1. Fetches all active organization memberships
+2. Filters out service accounts and invited (pending) users
+3. Maps membership data to Elba's user format
+4. Uses organization membership IDs for user identification (enabling deletion)
+
+### API Endpoints Used
+
+- `GET /api/v2/account/details` - Get authenticated user and organization info
+- `GET /api/v2/organizations/{org}/organization-memberships` - List organization members
+- `DELETE /api/v2/organization-memberships/{id}` - Remove a user from the organization
+
+### Environment Variables
+
+- `ELBA_SOURCE_ID`: UUID for your Elba source
+- `NANGO_INTEGRATION_ID`: Nango integration identifier
+- `NANGO_SECRET_KEY`: Nango API secret key
+- `TERRAFORM_API_BASE_URL`: Terraform API base URL (defaults to https://app.terraform.io)
+- `TERRAFORM_USERS_SYNC_CRON`: Cron schedule for user sync (defaults to daily at midnight)
+- `TERRAFORM_USERS_SYNC_BATCH_SIZE`: Number of users to fetch per page (defaults to 50)
+
+## Testing
+
+Run the test suite:
+
+```bash
+pnpm test        # Run tests once
+pnpm test:watch  # Run tests in watch mode
+```
+
+Run linting and type checking:
+
+```bash
+pnpm lint        # ESLint
+pnpm type-check  # TypeScript compiler
+```
+
+## Deployment
+
+The integration is deployed as a Next.js application. Ensure all environment variables are configured in your deployment platform.
+
+## Resources
+
+- [Terraform Cloud API Documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs)
+- [Elba Documentation](https://docs.elba.io)
+- [Nango Documentation](https://docs.nango.dev)
+- [Inngest Documentation](https://www.inngest.com/docs)

--- a/apps/terraform/next.config.js
+++ b/apps/terraform/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const { elbaNextConfig } = require('@elba-security/config/next');
+
+const nextConfig = {
+  ...elbaNextConfig,
+  transpilePackages: ['@elba-security/sdk'],
+};
+
+module.exports = nextConfig;

--- a/apps/terraform/package.json
+++ b/apps/terraform/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@elba-security/terraform",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 4000",
+    "dev:inngest": "inngest-cli dev -u http://localhost:4000/api/inngest",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elba-security/common": "workspace:*",
+    "@elba-security/config": "workspace:*",
+    "@elba-security/inngest": "workspace:*",
+    "@elba-security/logger": "workspace:*",
+    "@elba-security/nextjs": "workspace:*",
+    "@elba-security/utils": "workspace:*",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "catalog:",
+    "@elba-security/eslint-config-custom": "workspace:*",
+    "@elba-security/test-utils": "workspace:*",
+    "@elba-security/tsconfig": "workspace:*",
+    "@next/eslint-plugin-next": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "dotenv": "catalog:",
+    "eslint": "catalog:",
+    "msw": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/terraform/src/app/api/inngest/route.ts
+++ b/apps/terraform/src/app/api/inngest/route.ts
@@ -1,0 +1,20 @@
+import { elbaInngestClient } from '@/inngest/client';
+
+/**
+ * Inngest webhook handler for processing asynchronous events.
+ * This endpoint:
+ * 1. Receives events from Inngest
+ * 2. Routes them to the appropriate function handlers
+ * 3. Returns the function execution results
+ *
+ * Configuration:
+ * - Uses Edge runtime for better performance
+ * - Enables streaming for longer running functions
+ * - Forces dynamic rendering to ensure fresh data
+ */
+
+export const preferredRegion = 'iad1';
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export const { GET, POST, PUT } = elbaInngestClient.serve();

--- a/apps/terraform/src/app/layout.tsx
+++ b/apps/terraform/src/app/layout.tsx
@@ -1,0 +1,18 @@
+/**
+ * This file is required by nextjs and has no purpose for now in the integration.
+ * It should not be edited or removed.
+ */
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: `Elba x terraform`,
+  description: 'Elba x terraform',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/terraform/src/app/page.tsx
+++ b/apps/terraform/src/app/page.tsx
@@ -1,0 +1,14 @@
+/**
+ * This file is required by nextjs and has no purpose for now in the integration.
+ * It should not be edited or removed.
+ */
+
+/**
+ * Home page component that displays when accessing the root URL.
+ * This is a placeholder page - in production, users will be redirected
+ * to the Elba dashboard after installation.
+ */
+export default function Home() {
+  const title = `Elba x terraform`;
+  return <main>{title}</main>;
+}

--- a/apps/terraform/src/common/env.ts
+++ b/apps/terraform/src/common/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const zEnvInt = () => z.coerce.number().int().positive();
+
+export const env = z
+  .object({
+    // Elba configuration
+    ELBA_SOURCE_ID: z.string().uuid(),
+
+    // Nango configuration
+    NANGO_INTEGRATION_ID: z.string().min(1),
+    NANGO_SECRET_KEY: z.string().min(1),
+
+    // Source configuration
+    TERRAFORM_API_BASE_URL: z.string().url().default('https://app.terraform.io'),
+    TERRAFORM_USERS_SYNC_CRON: z.string().default('0 0 * * *'),
+    TERRAFORM_USERS_SYNC_BATCH_SIZE: zEnvInt().default(50),
+  })
+  .parse(process.env);

--- a/apps/terraform/src/connectors/terraform/users.test.ts
+++ b/apps/terraform/src/connectors/terraform/users.test.ts
@@ -1,0 +1,405 @@
+import { http } from 'msw';
+import { describe, expect, test, beforeEach } from 'vitest';
+import { server } from '@elba-security/test-utils/vitest/setup-msw-handlers';
+import { IntegrationConnectionError, IntegrationError } from '@elba-security/common';
+import { env } from '@/common/env';
+import type { TerraformOrganizationMembership, TerraformUser } from './users';
+import {
+  getOrganizationMemberships,
+  getAuthenticatedUserOrganization,
+  deleteOrganizationMembership,
+} from './users';
+
+// Test data setup
+const validToken = 'tfp.abc123';
+const organizationName = 'test-org';
+
+// Create sample users
+const createUser = (id: string, username: string): TerraformUser => ({
+  id,
+  type: 'users',
+  attributes: {
+    username,
+    'avatar-url': `https://www.gravatar.com/avatar/${id}`,
+    'is-service-account': false,
+    'two-factor': {
+      enabled: true,
+    },
+  },
+  links: {
+    self: `/api/v2/users/${id}`,
+  },
+});
+
+// Create sample organization memberships
+const createMembership = (
+  id: string,
+  email: string,
+  userId: string | null,
+  username: string | null = null
+): TerraformOrganizationMembership => ({
+  id,
+  type: 'organization-memberships',
+  attributes: {
+    email,
+    username,
+    status: 'active',
+  },
+  relationships: {
+    user: {
+      data: userId ? { id: userId, type: 'users' } : null,
+    },
+    teams: {
+      data: [{ id: 'team-123', type: 'teams' }],
+    },
+  },
+  links: {
+    self: `/api/v2/organization-memberships/${id}`,
+  },
+});
+
+describe('users connector', () => {
+  describe('getOrganizationMemberships', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(
+          `${env.TERRAFORM_API_BASE_URL}/api/v2/organizations/${organizationName}/organization-memberships`,
+          ({ request }) => {
+            if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+              return new Response(undefined, { status: 401 });
+            }
+
+            const url = new URL(request.url);
+            const page = url.searchParams.get('page[number]');
+            const pageNumber = page ? parseInt(page) : 1;
+
+            const users = [
+              createUser('user-1', 'john.doe'),
+              createUser('user-2', 'jane.smith'),
+              createUser('user-3', 'service-account'),
+            ];
+
+            // Modify user-3 to be a service account
+            const serviceAccountUser = users[2];
+            if (serviceAccountUser) {
+              serviceAccountUser.attributes['is-service-account'] = true;
+            }
+
+            const memberships = [
+              createMembership('mem-1', 'john.doe@example.com', 'user-1', 'john.doe'),
+              createMembership('mem-2', 'jane.smith@example.com', 'user-2', 'jane.smith'),
+              createMembership('mem-3', 'service@example.com', 'user-3', 'service-account'),
+              createMembership('mem-4', 'invited@example.com', null, null), // Invited user without account
+            ];
+
+            const pageSize = 2;
+            const totalPages = Math.ceil(memberships.length / pageSize);
+            const startIdx = (pageNumber - 1) * pageSize;
+            const endIdx = startIdx + pageSize;
+            const pageData = memberships.slice(startIdx, endIdx);
+            const includedUsers = users.filter((user) =>
+              pageData.some((mem) => mem.relationships.user.data?.id === user.id)
+            );
+
+            return Response.json({
+              data: pageData,
+              included: includedUsers,
+              links: {
+                self: request.url,
+                first: `${env.TERRAFORM_API_BASE_URL}/api/v2/organizations/${organizationName}/organization-memberships?page[number]=1&page[size]=${pageSize}`,
+                prev:
+                  pageNumber > 1
+                    ? `${
+                        env.TERRAFORM_API_BASE_URL
+                      }/api/v2/organizations/${organizationName}/organization-memberships?page[number]=${
+                        pageNumber - 1
+                      }&page[size]=${pageSize}`
+                    : null,
+                next:
+                  pageNumber < totalPages
+                    ? `${
+                        env.TERRAFORM_API_BASE_URL
+                      }/api/v2/organizations/${organizationName}/organization-memberships?page[number]=${
+                        pageNumber + 1
+                      }&page[size]=${pageSize}`
+                    : null,
+                last: `${env.TERRAFORM_API_BASE_URL}/api/v2/organizations/${organizationName}/organization-memberships?page[number]=${totalPages}&page[size]=${pageSize}`,
+              },
+              meta: {
+                pagination: {
+                  'current-page': pageNumber,
+                  'page-size': pageSize,
+                  'prev-page': pageNumber > 1 ? pageNumber - 1 : null,
+                  'next-page': pageNumber < totalPages ? pageNumber + 1 : null,
+                  'total-pages': totalPages,
+                  'total-count': memberships.length,
+                },
+              },
+            });
+          }
+        )
+      );
+    });
+
+    test('should return memberships with user data for the first page', async () => {
+      const result = await getOrganizationMemberships({
+        accessToken: validToken,
+        organizationName,
+        page: null,
+      });
+
+      expect(result.memberships).toHaveLength(2);
+      expect(result.memberships[0]).toMatchObject({
+        membership: {
+          id: 'mem-1',
+          attributes: {
+            email: 'john.doe@example.com',
+            username: 'john.doe',
+          },
+        },
+        user: {
+          id: 'user-1',
+          attributes: {
+            username: 'john.doe',
+          },
+        },
+      });
+      expect(result.nextPage).toBe(2);
+    });
+
+    test('should return memberships for the second page', async () => {
+      const result = await getOrganizationMemberships({
+        accessToken: validToken,
+        organizationName,
+        page: 2,
+      });
+
+      expect(result.memberships).toHaveLength(2);
+      expect(result.memberships[0]).toMatchObject({
+        membership: {
+          id: 'mem-3',
+          attributes: {
+            email: 'service@example.com',
+            username: 'service-account',
+          },
+        },
+        user: {
+          id: 'user-3',
+          attributes: {
+            'is-service-account': true,
+          },
+        },
+      });
+      expect(result.nextPage).toBeNull();
+    });
+
+    test('should handle invited users without user data', async () => {
+      const result = await getOrganizationMemberships({
+        accessToken: validToken,
+        organizationName,
+        page: 2,
+      });
+
+      const invitedMember = result.memberships.find((m) => m.membership.id === 'mem-4');
+      expect(invitedMember).toBeDefined();
+      expect(invitedMember?.user).toBeNull();
+    });
+
+    test('should throw IntegrationConnectionError on 401', async () => {
+      await expect(
+        getOrganizationMemberships({
+          accessToken: 'invalid-token',
+          organizationName,
+          page: null,
+        })
+      ).rejects.toThrow(new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' }));
+    });
+
+    test('should throw IntegrationError on other errors', async () => {
+      server.use(
+        http.get(
+          `${env.TERRAFORM_API_BASE_URL}/api/v2/organizations/${organizationName}/organization-memberships`,
+          () => new Response(undefined, { status: 500 })
+        )
+      );
+
+      await expect(
+        getOrganizationMemberships({
+          accessToken: validToken,
+          organizationName,
+          page: null,
+        })
+      ).rejects.toThrow(IntegrationError);
+    });
+  });
+
+  describe('getAuthenticatedUserOrganization', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${env.TERRAFORM_API_BASE_URL}/api/v2/account/details`, ({ request }) => {
+          if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+            return new Response(undefined, { status: 401 });
+          }
+
+          return Response.json({
+            data: {
+              id: 'user-auth',
+              type: 'users',
+              attributes: {
+                username: 'auth-user',
+                email: 'auth@example.com',
+                'avatar-url': 'https://www.gravatar.com/avatar/auth',
+                'is-service-account': false,
+                'two-factor': {
+                  enabled: true,
+                },
+              },
+              relationships: {
+                organizations: {
+                  data: [
+                    {
+                      id: organizationName,
+                      type: 'organizations',
+                    },
+                  ],
+                },
+              },
+            },
+          });
+        })
+      );
+    });
+
+    test('should return user and organization data', async () => {
+      const result = await getAuthenticatedUserOrganization(validToken);
+
+      expect(result).toEqual({
+        userId: 'user-auth',
+        username: 'auth-user',
+        email: 'auth@example.com',
+        organizationName,
+      });
+    });
+
+    test('should throw IntegrationConnectionError when user has no organizations', async () => {
+      server.use(
+        http.get(`${env.TERRAFORM_API_BASE_URL}/api/v2/account/details`, ({ request }) => {
+          if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+            return new Response(undefined, { status: 401 });
+          }
+
+          return Response.json({
+            data: {
+              id: 'user-auth',
+              type: 'users',
+              attributes: {
+                username: 'auth-user',
+                email: 'auth@example.com',
+                'avatar-url': null,
+                'is-service-account': false,
+                'two-factor': {
+                  enabled: false,
+                },
+              },
+              relationships: {
+                organizations: {
+                  data: [],
+                },
+              },
+            },
+          });
+        })
+      );
+
+      await expect(getAuthenticatedUserOrganization(validToken)).rejects.toThrow(
+        new IntegrationConnectionError('User has no organizations', { type: 'not_admin' })
+      );
+    });
+
+    test('should throw IntegrationConnectionError on 401', async () => {
+      await expect(getAuthenticatedUserOrganization('invalid-token')).rejects.toThrow(
+        new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' })
+      );
+    });
+
+    test('should throw IntegrationError on other errors', async () => {
+      server.use(
+        http.get(
+          `${env.TERRAFORM_API_BASE_URL}/api/v2/account/details`,
+          () => new Response(undefined, { status: 500 })
+        )
+      );
+
+      await expect(getAuthenticatedUserOrganization(validToken)).rejects.toThrow(IntegrationError);
+    });
+  });
+
+  describe('deleteOrganizationMembership', () => {
+    const membershipId = 'mem-123';
+
+    beforeEach(() => {
+      server.use(
+        http.delete(
+          `${env.TERRAFORM_API_BASE_URL}/api/v2/organization-memberships/${membershipId}`,
+          ({ request }) => {
+            if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
+              return new Response(undefined, { status: 401 });
+            }
+
+            return new Response(undefined, { status: 204 });
+          }
+        )
+      );
+    });
+
+    test('should successfully delete organization membership', async () => {
+      await expect(
+        deleteOrganizationMembership({
+          accessToken: validToken,
+          membershipId,
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    test('should not throw error when membership not found', async () => {
+      server.use(
+        http.delete(
+          `${env.TERRAFORM_API_BASE_URL}/api/v2/organization-memberships/${membershipId}`,
+          () => new Response(undefined, { status: 404 })
+        )
+      );
+
+      await expect(
+        deleteOrganizationMembership({
+          accessToken: validToken,
+          membershipId,
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    test('should throw IntegrationConnectionError on 401', async () => {
+      await expect(
+        deleteOrganizationMembership({
+          accessToken: 'invalid-token',
+          membershipId,
+        })
+      ).rejects.toThrow(new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' }));
+    });
+
+    test('should throw IntegrationError on other errors', async () => {
+      server.use(
+        http.delete(
+          `${env.TERRAFORM_API_BASE_URL}/api/v2/organization-memberships/${membershipId}`,
+          () => new Response(undefined, { status: 500 })
+        )
+      );
+
+      await expect(
+        deleteOrganizationMembership({
+          accessToken: validToken,
+          membershipId,
+        })
+      ).rejects.toThrow(IntegrationError);
+    });
+  });
+});

--- a/apps/terraform/src/connectors/terraform/users.ts
+++ b/apps/terraform/src/connectors/terraform/users.ts
@@ -1,0 +1,299 @@
+import { z } from 'zod';
+import { IntegrationError, IntegrationConnectionError } from '@elba-security/common';
+import { env } from '@/common/env';
+
+// Terraform API schemas based on documentation
+const userAttributesSchema = z.object({
+  username: z.string(),
+  'avatar-url': z.string().nullable(),
+  'is-service-account': z.boolean(),
+  'two-factor': z.object({
+    enabled: z.boolean(),
+  }),
+});
+
+const userRelationshipsSchema = z.object({
+  'authentication-tokens': z.object({
+    links: z.object({
+      related: z.string(),
+    }),
+  }),
+});
+
+const userSchema = z.object({
+  id: z.string(),
+  type: z.literal('users'),
+  attributes: userAttributesSchema,
+  relationships: userRelationshipsSchema.optional(),
+  links: z.object({
+    self: z.string(),
+  }),
+});
+
+const organizationMembershipAttributesSchema = z.object({
+  email: z.string().email(),
+  username: z.string().nullable(),
+  status: z.enum(['invited', 'active']),
+});
+
+const organizationMembershipRelationshipsSchema = z.object({
+  user: z.object({
+    data: z
+      .object({
+        id: z.string(),
+        type: z.literal('users'),
+      })
+      .nullable(),
+  }),
+  teams: z.object({
+    data: z.array(
+      z.object({
+        id: z.string(),
+        type: z.literal('teams'),
+      })
+    ),
+  }),
+  'organization-membership-invitation': z
+    .object({
+      data: z
+        .object({
+          id: z.string(),
+          type: z.literal('organization-membership-invitations'),
+        })
+        .nullable(),
+    })
+    .optional(),
+});
+
+const organizationMembershipSchema = z.object({
+  id: z.string(),
+  type: z.literal('organization-memberships'),
+  attributes: organizationMembershipAttributesSchema,
+  relationships: organizationMembershipRelationshipsSchema,
+  links: z.object({
+    self: z.string(),
+  }),
+});
+
+// Response schema for listing organization memberships
+const getOrganizationMembershipsResponseSchema = z.object({
+  data: z.array(organizationMembershipSchema),
+  included: z.array(userSchema).optional(),
+  links: z.object({
+    self: z.string(),
+    first: z.string(),
+    prev: z.string().nullable(),
+    next: z.string().nullable(),
+    last: z.string(),
+  }),
+  meta: z.object({
+    pagination: z.object({
+      'current-page': z.number(),
+      'page-size': z.number(),
+      'prev-page': z.number().nullable(),
+      'next-page': z.number().nullable(),
+      'total-pages': z.number(),
+      'total-count': z.number(),
+    }),
+  }),
+});
+
+// Export schemas and types
+export const terraformOrganizationMembershipSchema = organizationMembershipSchema;
+export type TerraformOrganizationMembership = z.infer<typeof organizationMembershipSchema>;
+export type TerraformUser = z.infer<typeof userSchema>;
+
+// Parameters required to fetch organization memberships
+type GetOrganizationMembershipsParams = {
+  accessToken: string;
+  organizationName: string;
+  page?: number | null;
+};
+
+/**
+ * Fetches organization memberships from Terraform API with pagination support
+ * @param params - Parameters required to fetch memberships
+ * @returns Object containing memberships with user data and pagination info
+ */
+export const getOrganizationMemberships = async ({
+  accessToken,
+  organizationName,
+  page,
+}: GetOrganizationMembershipsParams) => {
+  const url = new URL(
+    `/api/v2/organizations/${organizationName}/organization-memberships`,
+    env.TERRAFORM_API_BASE_URL
+  );
+
+  // Add pagination parameters
+  url.searchParams.append('page[size]', String(env.TERRAFORM_USERS_SYNC_BATCH_SIZE));
+  if (page) {
+    url.searchParams.append('page[number]', String(page));
+  }
+
+  // Include user data in the response
+  url.searchParams.append('include', 'user');
+
+  // Filter only active members
+  url.searchParams.append('filter[status]', 'active');
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.api+json',
+      'Content-Type': 'application/vnd.api+json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' });
+    }
+    throw new IntegrationError('Could not retrieve organization memberships', { response });
+  }
+
+  const resData: unknown = await response.json();
+  const result = getOrganizationMembershipsResponseSchema.parse(resData);
+
+  // Create a map of users for easy lookup
+  const usersMap = new Map<string, TerraformUser>();
+  if (result.included) {
+    for (const user of result.included) {
+      usersMap.set(user.id, user);
+    }
+  }
+
+  // Combine membership and user data
+  const membershipsWithUsers = result.data.map((membership) => {
+    const userId = membership.relationships.user.data?.id;
+    const user = userId ? usersMap.get(userId) : null;
+    return {
+      membership,
+      user,
+    };
+  });
+
+  return {
+    memberships: membershipsWithUsers,
+    nextPage: result.meta.pagination['next-page'],
+  };
+};
+
+/**
+ * Deletes a user from the organization
+ * @param params - Parameters including access token and membership ID
+ */
+export const deleteOrganizationMembership = async ({
+  accessToken,
+  membershipId,
+}: {
+  accessToken: string;
+  membershipId: string;
+}) => {
+  const url = new URL(
+    `/api/v2/organization-memberships/${membershipId}`,
+    env.TERRAFORM_API_BASE_URL
+  );
+
+  const response = await fetch(url.toString(), {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.api+json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' });
+    }
+    if (response.status === 404) {
+      // User already deleted or doesn't exist
+      return;
+    }
+    throw new IntegrationError('Could not delete organization membership', { response });
+  }
+};
+
+/**
+ * Fetches the authenticated user's information and organization details
+ * Used for validating access tokens and getting organization name
+ */
+export const getAuthenticatedUserOrganization = async (accessToken: string) => {
+  // First, we need to get the authenticated user details
+  const response = await fetch(`${env.TERRAFORM_API_BASE_URL}/api/v2/account/details`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.api+json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new IntegrationConnectionError('Unauthorized', { type: 'unauthorized' });
+    }
+    throw new IntegrationError('Could not retrieve account details', { response });
+  }
+
+  const resData: unknown = await response.json();
+
+  // Parse the account details response
+  const accountDetailsSchema = z.object({
+    data: z.object({
+      id: z.string(),
+      type: z.literal('users'),
+      attributes: z.object({
+        username: z.string(),
+        email: z.string().email(),
+        'avatar-url': z.string().nullable(),
+        'is-service-account': z.boolean(),
+        'two-factor': z.object({
+          enabled: z.boolean(),
+        }),
+      }),
+      relationships: z.object({
+        organizations: z.object({
+          data: z.array(
+            z.object({
+              id: z.string(),
+              type: z.literal('organizations'),
+            })
+          ),
+        }),
+      }),
+    }),
+  });
+
+  const accountResult = accountDetailsSchema.safeParse(resData);
+  if (!accountResult.success) {
+    throw new IntegrationConnectionError('Invalid account data', {
+      type: 'unknown',
+      metadata: { data: resData, errors: accountResult.error.issues },
+    });
+  }
+
+  // Get the first organization (most users have one organization)
+  const organizations = accountResult.data.data.relationships.organizations.data;
+  if (organizations.length === 0) {
+    throw new IntegrationConnectionError('User has no organizations', {
+      type: 'not_admin',
+    });
+  }
+
+  // Return user data and organization name
+  const firstOrg = organizations[0];
+  if (!firstOrg) {
+    throw new IntegrationConnectionError('User has no organizations', {
+      type: 'not_admin',
+    });
+  }
+
+  return {
+    userId: accountResult.data.data.id,
+    username: accountResult.data.data.attributes.username,
+    email: accountResult.data.data.attributes.email,
+    organizationName: firstOrg.id, // Organization ID is the name in Terraform
+  };
+};

--- a/apps/terraform/src/inngest/client.ts
+++ b/apps/terraform/src/inngest/client.ts
@@ -1,0 +1,77 @@
+import { ElbaInngestClient } from '@elba-security/inngest';
+import { env } from '@/common/env';
+import {
+  getOrganizationMemberships,
+  getAuthenticatedUserOrganization,
+  deleteOrganizationMembership,
+} from '@/connectors/terraform/users';
+
+export const elbaInngestClient = new ElbaInngestClient({
+  name: 'terraform',
+  nangoAuthType: 'OAUTH2',
+  nangoIntegrationId: env.NANGO_INTEGRATION_ID,
+  nangoSecretKey: env.NANGO_SECRET_KEY,
+  sourceId: env.ELBA_SOURCE_ID,
+});
+
+elbaInngestClient.createElbaUsersSyncSchedulerFn(env.TERRAFORM_USERS_SYNC_CRON);
+
+elbaInngestClient.createElbaUsersSyncFn(async ({ connection, cursor }) => {
+  // Get the organization name from the authenticated user
+  const { organizationName, userId: authUserId } = await getAuthenticatedUserOrganization(
+    connection.credentials.access_token
+  );
+
+  // Fetch organization memberships with user data
+  const result = await getOrganizationMemberships({
+    accessToken: connection.credentials.access_token,
+    organizationName,
+    page: cursor ? Number(cursor) : null,
+  });
+
+  // Transform memberships to Elba user format
+  const users = result.memberships
+    .filter((item) => {
+      // Skip if no user data or if it's the authenticated user
+      if (!item.user || item.user.id === authUserId) {
+        return false;
+      }
+      // Skip service accounts
+      if (item.user.attributes['is-service-account']) {
+        return false;
+      }
+      return true;
+    })
+    .map((item) => ({
+      id: item.membership.id, // Use membership ID as user ID for deletion
+      displayName: item.membership.attributes.username || item.membership.attributes.email,
+      email: item.membership.attributes.email,
+      additionalEmails: [],
+      isSuspendable: true, // Regular users can be suspended
+      metadata: {
+        organizationMembershipId: item.membership.id,
+        userId: item.user?.id || '',
+      },
+    }));
+
+  return {
+    users,
+    cursor: result.nextPage ? String(result.nextPage) : null,
+  };
+});
+
+elbaInngestClient.createInstallationValidateFn(async ({ connection }) => {
+  // Validate the connection by getting authenticated user and organization
+  await getAuthenticatedUserOrganization(connection.credentials.access_token);
+});
+
+elbaInngestClient.createElbaUsersDeleteFn({
+  isBatchDeleteSupported: false,
+  deleteUsersFn: async ({ connection, id }) => {
+    const oauth2Connection = connection as { credentials: { access_token: string } };
+    await deleteOrganizationMembership({
+      accessToken: oauth2Connection.credentials.access_token,
+      membershipId: id,
+    });
+  },
+});

--- a/apps/terraform/tsconfig.json
+++ b/apps/terraform/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@elba-security/tsconfig/nextjs.json",
+  "compilerOptions": {
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "allowJs": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/terraform/vercel.json
+++ b/apps/terraform/vercel.json
@@ -1,0 +1,8 @@
+{
+  "ignoreCommand": "npx turbo-ignore --fallback=HEAD^1",
+  "functions": {
+    "src/app/api/**/*": {
+      "maxDuration": 60
+    }
+  }
+}

--- a/apps/terraform/vitest.config.mts
+++ b/apps/terraform/vitest.config.mts
@@ -1,0 +1,26 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+import { config } from 'dotenv';
+import type { BuiltinEnvironment } from 'vitest';
+
+const { error } = config({ path: '.env.test' });
+
+if (error) {
+  throw new Error(`Could not find environment variables file: .env.test`);
+}
+
+const environment: BuiltinEnvironment = 'edge-runtime';
+
+process.env.VITEST_ENVIRONMENT = environment;
+
+export default defineConfig({
+  test: {
+    setupFiles: ['@elba-security/test-utils/vitest/setup-msw-handlers'],
+    environment,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5461,6 +5461,79 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.14.2)(msw@2.3.1(typescript@5.8.3))
 
+  apps/terraform:
+    dependencies:
+      '@elba-security/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@elba-security/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@elba-security/inngest':
+        specifier: workspace:*
+        version: link:../../packages/inngest
+      '@elba-security/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      '@elba-security/nextjs':
+        specifier: workspace:*
+        version: link:../../packages/nextjs
+      '@elba-security/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      next:
+        specifier: 'catalog:'
+        version: 14.2.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react:
+        specifier: 'catalog:'
+        version: 18.2.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
+    devDependencies:
+      '@edge-runtime/vm':
+        specifier: 'catalog:'
+        version: 3.2.0
+      '@elba-security/eslint-config-custom':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config-custom
+      '@elba-security/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
+      '@elba-security/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@next/eslint-plugin-next':
+        specifier: 'catalog:'
+        version: 14.2.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.14.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.2.79
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.2.25
+      dotenv:
+        specifier: 'catalog:'
+        version: 16.4.5
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.3.1(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.1.2(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.14.2)(msw@2.3.1(typescript@5.8.3))
+
   apps/typeform:
     dependencies:
       '@elba-security/common':


### PR DESCRIPTION
## Summary
This PR adds a new integration for Terraform Cloud/Enterprise to sync organization members with Elba Security.

## Features
- ✅ **User Synchronization**: Syncs active organization members from Terraform to Elba
- ✅ **User Deletion**: Support for removing users from Terraform organizations  
- ✅ **OAuth2 Authentication**: Configured through Nango
- ✅ **Pagination Support**: Handles large organizations efficiently
- ✅ **Service Account Filtering**: Excludes service accounts from sync

## Implementation Details

### API Endpoints Used
- `GET /api/v2/account/details` - Get authenticated user and organization info
- `GET /api/v2/organizations/{org}/organization-memberships` - List organization members with pagination
- `DELETE /api/v2/organization-memberships/{id}` - Remove a user from the organization

### Key Design Decisions
1. Uses organization membership IDs as user IDs to enable deletion
2. Filters out service accounts and pending invitations
3. Excludes the authenticated user from suspension to prevent self-lockout

## Testing
- ✅ All tests passing (13 tests)
- ✅ ESLint: No warnings or errors  
- ✅ TypeScript: No type errors

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of my own code
- [x] Tests added for new functionality
- [x] All tests passing
- [x] Documentation updated (README.md)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>