### PR TITLE
feat(onedrive & sharepoint): add logs to getDeltaItems request [E-3450]

### DIFF
--- a/apps/onedrive/src/connectors/microsoft/delta/delta.test.ts
+++ b/apps/onedrive/src/connectors/microsoft/delta/delta.test.ts
@@ -50,10 +50,12 @@ describe('delta connector', () => {
           `${env.MICROSOFT_API_URL}/users/:userId/drive/root/delta`,
           ({ request, params }) => {
             if (request.headers.get('Authorization') !== `Bearer ${validToken}`) {
-              return new Response(undefined, { status: 401 });
+              return new Response(JSON.stringify({ message: 'missing token' }), { status: 401 });
             }
             if (params.userId !== userId) {
-              return new Response(undefined, { status: 404 });
+              return new Response(JSON.stringify({ message: "User don't have a drive" }), {
+                status: 404,
+              });
             }
 
             const url = new URL(request.url);

--- a/apps/onedrive/src/connectors/microsoft/delta/delta.ts
+++ b/apps/onedrive/src/connectors/microsoft/delta/delta.ts
@@ -64,6 +64,10 @@ export const getDeltaItems = async ({
   });
 
   if (!response.ok) {
+    const errorInfo = (await response.clone().json()) as object;
+
+    logger.error('Onedrive delta items MS Graph error', errorInfo);
+
     if (response.status === 404) {
       return null;
     }

--- a/apps/sharepoint/src/connectors/microsoft/delta/delta.test.ts
+++ b/apps/sharepoint/src/connectors/microsoft/delta/delta.test.ts
@@ -44,7 +44,7 @@ describe('delta connector', () => {
               params.siteId !== siteId ||
               params.driveId !== driveId
             ) {
-              return new Response(undefined, { status: 401 });
+              return new Response(JSON.stringify({ message: 'missing token' }), { status: 401 });
             }
             const url = new URL(request.url);
             const select = url.searchParams.get('$select');

--- a/apps/sharepoint/src/connectors/microsoft/delta/delta.ts
+++ b/apps/sharepoint/src/connectors/microsoft/delta/delta.ts
@@ -62,6 +62,10 @@ export const getDeltaItems = async ({
   });
 
   if (!response.ok) {
+    const errorInfo = (await response.clone().json()) as object;
+
+    logger.error('Onedrive delta items MS Graph error', errorInfo);
+
     throw new MicrosoftError('Could not retrieve delta', { response });
   }
 

--- a/apps/sharepoint/src/connectors/microsoft/delta/delta.ts
+++ b/apps/sharepoint/src/connectors/microsoft/delta/delta.ts
@@ -64,7 +64,7 @@ export const getDeltaItems = async ({
   if (!response.ok) {
     const errorInfo = (await response.clone().json()) as object;
 
-    logger.error('Onedrive delta items MS Graph error', errorInfo);
+    logger.error('Sharepoint delta items MS Graph error', errorInfo);
 
     throw new MicrosoftError('Could not retrieve delta', { response });
   }


### PR DESCRIPTION
## Description
Ticket [E-3450](https://linear.app/elba/issue/E-3450/investigate-sharepoint-and-onedrive-integrations-errors)

We have plenty errors for both integrations (onedrive and sharepoint) in `getDeltaItems` function. According to logs we are receiving 410 from MS Graph, potentially it could be this issue - https://learn.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http#response-2

> There may be cases when the service can't provide a list of changes for a given token (for example, if a client tries to reuse an old token after being disconnected for a long time, or if server state has changed and a new token is required). In these cases the service returns an HTTP 410 Gone error with an error response containing one of the error codes below, and a Location header containing a new nextLink that starts a fresh delta enumeration from scratch. After finishing the full enumeration, compare the returned items with your local state and follow these instructions.

But we are always updating the token, so I'm not sure. As it is impossible to trigger this flow, I've added logs so we can be sure about the issue we need to solve


## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests to cover the new feature or fixes.
