### PR TITLE
feat(gmail): allow an organisation to be sync several time a day

### DIFF
--- a/apps/gmail/src/inngest/functions/third-party-apps/analyze-email.test.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/analyze-email.test.ts
@@ -55,6 +55,7 @@ const eventData: AnalyzeEmailRequested['gmail/third_party_apps.email.analyze.req
   userId: 'user-id',
   email: 'user@foo.com',
   message: shadowItMessage,
+  syncStartedAt: new Date().toISOString(),
 };
 
 describe('analyzeEmail', () => {

--- a/apps/gmail/src/inngest/functions/third-party-apps/analyze-email.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/analyze-email.ts
@@ -42,6 +42,7 @@ export type AnalyzeEmailRequested = {
         to: string;
         body: string;
       };
+      syncStartedAt: string;
     };
   };
 };
@@ -52,7 +53,7 @@ export const analyzeEmail = inngest.createFunction(
     concurrency: concurrencyOption,
     retries: 3,
     rateLimit: {
-      key: 'event.data.organisationId + "-" + event.data.userId + "-" + event.data.message.from',
+      key: 'event.data.syncStartedAt + "-" + event.data.organisationId + "-" + event.data.userId + "-" + event.data.message.from',
       period: '24h',
       limit: 1,
     },

--- a/apps/gmail/src/inngest/functions/third-party-apps/sync-email.test.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/sync-email.test.ts
@@ -14,6 +14,7 @@ const eventData: SyncEmailRequested['gmail/third_party_apps.email.sync.requested
   userId: 'user-id',
   email: 'user@foo.com',
   messageId: 'message-id',
+  syncStartedAt: new Date().toISOString(),
 };
 
 const message = {
@@ -91,6 +92,7 @@ describe('sync-email', () => {
           subject: await encryptElbaInngestText(message.subject),
           body: await encryptElbaInngestText(message.body),
         },
+        syncStartedAt: eventData.syncStartedAt,
       },
     });
   });

--- a/apps/gmail/src/inngest/functions/third-party-apps/sync-email.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/sync-email.ts
@@ -10,6 +10,7 @@ export type SyncEmailRequested = {
       userId: string;
       email: string;
       messageId: string;
+      syncStartedAt: string;
     };
   };
 };
@@ -37,7 +38,7 @@ export const syncEmail = inngest.createFunction(
     event: 'gmail/third_party_apps.email.sync.requested',
   },
   async ({ event, step }) => {
-    const { email, messageId, organisationId, userId, region } = event.data;
+    const { email, messageId, organisationId, userId, region, syncStartedAt } = event.data;
 
     const result = await step.invoke('get-message', {
       function: getGmailMessage,
@@ -70,6 +71,7 @@ export const syncEmail = inngest.createFunction(
           to: result.message.to,
           body: result.message.body,
         },
+        syncStartedAt,
       },
     });
   }

--- a/apps/gmail/src/inngest/functions/third-party-apps/sync-inbox.test.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/sync-inbox.test.ts
@@ -13,6 +13,7 @@ const eventData: SyncInboxRequested['gmail/third_party_apps.inbox.sync.requested
   email: 'user@foo.com',
   syncTo: '2025-06-01T00:00:00.000Z',
   syncFrom: '2025-06-02T00:00:00.000Z',
+  syncStartedAt: '2025-06-02T00:00:00.000Z',
   pageToken: null,
 };
 
@@ -103,6 +104,7 @@ describe('sync-inbox', () => {
             userId: eventData.userId,
             email: eventData.email,
             messageId: message.id,
+            syncStartedAt: eventData.syncStartedAt,
           },
         }))
       )

--- a/apps/gmail/src/inngest/functions/third-party-apps/sync-inbox.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/sync-inbox.ts
@@ -13,6 +13,7 @@ export type SyncInboxRequested = {
       pageToken: string | null; // google /emails pageToken
       syncFrom: string | null;
       syncTo: string;
+      syncStartedAt: string;
     };
   };
 };
@@ -40,7 +41,8 @@ export const syncInbox = inngest.createFunction(
     event: 'gmail/third_party_apps.inbox.sync.requested',
   },
   async ({ event, step }) => {
-    const { email, pageToken, organisationId, userId, region, syncFrom, syncTo } = event.data;
+    const { email, pageToken, organisationId, userId, region, syncFrom, syncTo, syncStartedAt } =
+      event.data;
 
     const { messages, nextPageToken } = await step.invoke('list-messages', {
       function: listGmailMessages,
@@ -70,6 +72,7 @@ export const syncInbox = inngest.createFunction(
             userId,
             email,
             messageId: id,
+            syncStartedAt,
           },
         }))
       );

--- a/apps/gmail/src/inngest/functions/third-party-apps/sync.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/sync.ts
@@ -93,6 +93,7 @@ export const syncThirdPartyApps = inngest.createFunction(
             pageToken: null,
             syncFrom: lastSyncStartedAt,
             syncTo: syncStartedAt,
+            syncStartedAt,
           },
         }))
       );


### PR DESCRIPTION
## Description
This PR allows an onrganisation to be sync several time during a 24h window

- add to `analyzeEmail` rate-limit key date of start of sync

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
