### PR TITLE
feat(emai-scanning): add logic pre-filter to Outlook & Gmail

### DIFF
--- a/apps/gmail/src/connectors/google/gmail.ts
+++ b/apps/gmail/src/connectors/google/gmail.ts
@@ -68,7 +68,7 @@ const messageSchema = z.object({
   body: z.string(),
 });
 
-type Message = z.infer<typeof messageSchema>;
+export type GmailMessage = z.infer<typeof messageSchema>;
 
 const parseRetrievedMessage = (batchedResponse: BatchResponse) => {
   try {
@@ -149,7 +149,7 @@ export const listMessages = async ({
     },
     {
       nextPageToken,
-      messages: [] as Message[],
+      messages: [] as GmailMessage[],
       errors: [] as unknown[],
     }
   );

--- a/apps/gmail/src/inngest/functions/third-party-apps/sync-inbox.test.ts
+++ b/apps/gmail/src/inngest/functions/third-party-apps/sync-inbox.test.ts
@@ -20,15 +20,22 @@ const eventData: SyncInboxRequested['gmail/third_party_apps.inbox.sync.requested
 
 const defaultMessages = [
   {
+    id: 'message-id-0',
+    from: 'personal@gmail.com',
+    to: 'to.1@to.com',
+    body: 'body 1',
+    subject: 'subject 1',
+  },
+  {
     id: 'message-id-1',
-    from: 'from.1@foo.com',
+    from: 'from.1@baz.com',
     to: 'to.1@to.com',
     body: 'body 1',
     subject: 'subject 1',
   },
   {
     id: 'message-id-2',
-    from: 'from.2@foo.com',
+    from: 'from.2@baz.com',
     to: 'to.2@to.com',
     body: 'body 2',
     subject: 'subject 2',
@@ -112,26 +119,24 @@ describe('sync-inbox', () => {
 
     expect(step.sendEvent).toHaveBeenCalledWith(
       expect.any(String),
-      expect.arrayContaining(
-        await Promise.all(
-          defaultMessages.map(async (message) => ({
-            name: 'gmail/third_party_apps.email.analyze.requested',
-            data: {
-              organisationId,
-              region: eventData.region,
-              userId: eventData.userId,
-              email: eventData.email,
-              message: {
-                ...message,
-                from: await encryptElbaInngestText(message.from),
-                to: await encryptElbaInngestText(message.to),
-                subject: await encryptElbaInngestText(message.subject),
-                body: await encryptElbaInngestText(message.body),
-              },
-              syncStartedAt: eventData.syncStartedAt,
+      await Promise.all(
+        defaultMessages.slice(1, defaultMessages.length).map(async (message) => ({
+          name: 'gmail/third_party_apps.email.analyze.requested',
+          data: {
+            organisationId,
+            region: eventData.region,
+            userId: eventData.userId,
+            email: eventData.email,
+            message: {
+              ...message,
+              from: await encryptElbaInngestText(message.from),
+              to: await encryptElbaInngestText(message.to),
+              subject: await encryptElbaInngestText(message.subject),
+              body: await encryptElbaInngestText(message.body),
             },
-          }))
-        )
+            syncStartedAt: eventData.syncStartedAt,
+          },
+        }))
       )
     );
   });

--- a/apps/outlook/src/connectors/microsoft/message/mock.ts
+++ b/apps/outlook/src/connectors/microsoft/message/mock.ts
@@ -1,18 +1,43 @@
 export const outlookMessages = [
   {
+    id: 'AAMkAGE4NmEwMmU2LTViYTctNDhhNi05ZTI3LWI3NzkyZGY5M2Q5NQBGAAAAAAAMB2R4SroqRYvgvUoGmDOtB_message-0',
+    subject: 'subject-message-0',
+    from: {
+      emailAddress: {
+        name: 'from-name-0',
+        address: 'from-0@gmail.com',
+      },
+    },
+    toRecipients: [
+      {
+        emailAddress: {
+          name: 'to-name-0',
+          address: 'to-0@acme.com',
+        },
+      },
+    ],
+    body: {
+      contentType: 'html',
+      content: 'html-content: message-text-0',
+    },
+    isDraft: false,
+    createdDateTime: '2025-04-08T10:00:00Z',
+    hasAttachments: false,
+  },
+  {
     id: 'AAMkAGE4NmEwMmU2LTViYTctNDhhNi05ZTI3LWI3NzkyZGY5M2Q5NQBGAAAAAAAMB2R4SroqRYvgvUoGmDOtB_message-1',
     subject: 'subject-message-1',
     from: {
       emailAddress: {
         name: 'from-name-1',
-        address: 'from-email-address-1',
+        address: 'from-1@acme.com',
       },
     },
     toRecipients: [
       {
         emailAddress: {
           name: 'to-name-1',
-          address: 'to-email-address-1',
+          address: 'to-1@acme.com',
         },
       },
     ],
@@ -30,14 +55,14 @@ export const outlookMessages = [
     from: {
       emailAddress: {
         name: 'from-name-2',
-        address: 'from-email-address-2',
+        address: 'from-2@acme.com',
       },
     },
     toRecipients: [
       {
         emailAddress: {
           name: 'to-name-2',
-          address: 'to-email-address-2',
+          address: 'to-2@acme.com',
         },
       },
     ],
@@ -55,14 +80,14 @@ export const outlookMessages = [
     from: {
       emailAddress: {
         name: 'from-name-3',
-        address: 'from-email-address-3',
+        address: 'from-3@acme.com',
       },
     },
     toRecipients: [
       {
         emailAddress: {
           name: 'to-name-3',
-          address: 'to-email-address-3',
+          address: 'to-3@acme.com',
         },
       },
     ],
@@ -80,14 +105,14 @@ export const outlookMessages = [
     from: {
       emailAddress: {
         name: 'from-name-4',
-        address: 'from-email-address-4',
+        address: 'from-4@acme.com',
       },
     },
     toRecipients: [
       {
         emailAddress: {
           name: 'to-name-4',
-          address: 'to-email-address-4',
+          address: 'to-4@acme.com',
         },
       },
     ],

--- a/apps/outlook/src/inngest/functions/third-party-apps/sync-messages.test.ts
+++ b/apps/outlook/src/inngest/functions/third-party-apps/sync-messages.test.ts
@@ -6,6 +6,7 @@ import { organisationsTable } from '@/database/schema';
 import { db } from '@/database/client';
 import { outlookMessages } from '@/connectors/microsoft/message/mock';
 import * as authConnector from '@/connectors/microsoft/auth';
+import { encryptElbaInngestText } from '@/common/crypto';
 import { syncMessages, type SyncMessagesRequested } from './sync-messages';
 
 const mockFunction = createInngestFunctionMock(
@@ -18,10 +19,6 @@ const region = 'eu';
 const userId = 'user-id';
 const tenantId = 'tenant-id';
 
-vi.mock('@/common/crypto', () => ({
-  decrypt: vi.fn(() => token),
-}));
-
 vi.spyOn(authConnector, 'getToken').mockResolvedValue({
   token,
   expiresIn: 3600,
@@ -30,15 +27,17 @@ vi.spyOn(authConnector, 'getToken').mockResolvedValue({
 const organisationId = '4f9b95b1-07ec-4356-971c-5a9d328e911c';
 const syncStartedAt = new Date().toISOString();
 
-export const defaultMessages: OutlookMessage[] = outlookMessages.map((message) => ({
-  id: message.id,
-  subject: `encrypted(${message.subject})`,
-  from: `encrypted(${message.from.emailAddress.address})`,
-  toRecipients: message.toRecipients
-    .map((item) => `encrypted(${item.emailAddress.address})`)
-    .join(', '),
-  body: `encrypted(${message.body.content})`,
-}));
+export const defaultMessages: OutlookMessage[] = await Promise.all(
+  outlookMessages.map(async (message) => ({
+    id: message.id,
+    subject: await encryptElbaInngestText(message.subject),
+    from: await encryptElbaInngestText(message.from.emailAddress.address),
+    toRecipients: await Promise.all(
+      message.toRecipients.map((item) => encryptElbaInngestText(item.emailAddress.address))
+    ).then((toRecipients) => toRecipients.join(', ')),
+    body: await encryptElbaInngestText(message.body.content),
+  }))
+);
 
 const eventData: SyncMessagesRequested['outlook/third_party_apps.messages.sync.requested']['data'] =
   {
@@ -50,6 +49,7 @@ const eventData: SyncMessagesRequested['outlook/third_party_apps.messages.sync.r
     skipStep: 'skip-step',
     syncStartedAt,
     tenantId,
+    mail: 'receiver@foo.com',
   };
 
 const setup = async ({
@@ -126,7 +126,7 @@ describe('sync-messages', () => {
 
     expect(step.sendEvent).toHaveBeenCalledWith(
       'analyze-email',
-      defaultMessages.map((message) => ({
+      defaultMessages.slice(1, defaultMessages.length).map((message) => ({
         name: 'outlook/third_party_apps.email.analyze.requested',
         data: {
           organisationId,
@@ -189,7 +189,7 @@ describe('sync-messages', () => {
     expect(step.sendEvent).toHaveBeenNthCalledWith(
       1,
       'analyze-email',
-      defaultMessages.map((message) => ({
+      defaultMessages.slice(1, defaultMessages.length).map((message) => ({
         name: 'outlook/third_party_apps.email.analyze.requested',
         data: {
           organisationId,

--- a/apps/outlook/src/inngest/functions/third-party-apps/sync.test.ts
+++ b/apps/outlook/src/inngest/functions/third-party-apps/sync.test.ts
@@ -167,6 +167,7 @@ describe('third-party-apps-sync', () => {
           userId: user.id,
           syncStartedAt,
           tenantId,
+          mail: user.mail,
         },
       }))
     );
@@ -192,6 +193,7 @@ describe('third-party-apps-sync', () => {
           userId: user.id,
           syncStartedAt,
           tenantId,
+          mail: user.mail,
         },
       }))
     );

--- a/apps/outlook/src/inngest/functions/third-party-apps/sync.ts
+++ b/apps/outlook/src/inngest/functions/third-party-apps/sync.ts
@@ -79,6 +79,7 @@ export const syncThirdPartyApps = inngest.createFunction(
             syncFrom: lastSyncStartedAt,
             syncTo: syncStartedAt,
             userId: user.id,
+            mail: user.mail ?? null,
             syncStartedAt,
             tenantId,
           },

--- a/packages/utils/src/email-scanning.test.ts
+++ b/packages/utils/src/email-scanning.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { shouldAnalyzeEmail } from './email-scanning';
+
+describe('shouldAnalyzeEmail', () => {
+  it('should return true when sender and receiver have different business domains', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@company.com',
+      receiver: 'jane@othercorp.com',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return true when sender has business domain and receiver has personal domain', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@businesscorp.com',
+      receiver: 'jane@gmail.com',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return true when emails are in formatted strings', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'John Doe <john@company.com>',
+      receiver: 'Jane Smith <jane@othercorp.com>',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return true when emails are in quoted formatted strings', () => {
+    const result = shouldAnalyzeEmail({
+      sender: '"John Doe" <john@company.com>',
+      receiver: '"Jane Smith" <jane@othercorp.com>',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return false when sender and receiver have same domain', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@company.com',
+      receiver: 'jane@company.com',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when sender and receiver have same domain with different subdomains', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@mail.company.com',
+      receiver: 'jane@hr.company.com',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when sender has gmail.com domain', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@gmail.com',
+      receiver: 'jane@company.com',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when sender has a personal domain', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@msn.com',
+      receiver: 'jane@company.com',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when sender email cannot be extracted', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'invalid-email',
+      receiver: 'jane@othercorp.com',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when receiver email cannot be extracted', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'john@company.com',
+      receiver: 'invalid-email',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return false when both emails are invalid', () => {
+    const result = shouldAnalyzeEmail({
+      sender: 'invalid-sender',
+      receiver: 'invalid-receiver',
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/packages/utils/src/email-scanning.ts
+++ b/packages/utils/src/email-scanning.ts
@@ -1,0 +1,150 @@
+// source here: https://gist.github.com/Evavic44/8348e357935d09f79d4c1616b0c20408
+const PERSONAL_EMAIL_DOMAINS = [
+  'gmail.com',
+  'yahoo.com',
+  'hotmail.com',
+  'aol.com',
+  'hotmail.co.uk',
+  'hotmail.fr',
+  'msn.com',
+  'yahoo.fr',
+  'wanadoo.fr',
+  'orange.fr',
+  'comcast.net',
+  'yahoo.co.uk',
+  'yahoo.com.br',
+  'yahoo.co.in',
+  'live.com',
+  'rediffmail.com',
+  'free.fr',
+  'gmx.de',
+  'web.de',
+  'yandex.ru',
+  'ymail.com',
+  'libero.it',
+  'outlook.com',
+  'uol.com.br',
+  'bol.com.br',
+  'mail.ru',
+  'cox.net',
+  'hotmail.it',
+  'sbcglobal.net',
+  'sfr.fr',
+  'live.fr',
+  'verizon.net',
+  'live.co.uk',
+  'googlemail.com',
+  'yahoo.es',
+  'ig.com.br',
+  'live.nl',
+  'bigpond.com',
+  'terra.com.br',
+  'yahoo.it',
+  'neuf.fr',
+  'yahoo.de',
+  'alice.it',
+  'rocketmail.com',
+  'att.net',
+  'laposte.net',
+  'facebook.com',
+  'bellsouth.net',
+  'yahoo.in',
+  'hotmail.es',
+  'charter.net',
+  'yahoo.ca',
+  'yahoo.com.au',
+  'rambler.ru',
+  'hotmail.de',
+  'tiscali.it',
+  'shaw.ca',
+  'yahoo.co.jp',
+  'sky.com',
+  'earthlink.net',
+  'optonline.net',
+  'freenet.de',
+  't-online.de',
+  'aliceadsl.fr',
+  'virgilio.it',
+  'home.nl',
+  'qq.com',
+  'telenet.be',
+  'me.com',
+  'yahoo.com.ar',
+  'tiscali.co.uk',
+  'yahoo.com.mx',
+  'voila.fr',
+  'gmx.net',
+  'mail.com',
+  'planet.nl',
+  'tin.it',
+  'live.it',
+  'ntlworld.com',
+  'arcor.de',
+  'yahoo.co.id',
+  'frontiernet.net',
+  'hetnet.nl',
+  'live.com.au',
+  'yahoo.com.sg',
+  'zonnet.nl',
+  'club-internet.fr',
+  'juno.com',
+  'optusnet.com.au',
+  'blueyonder.co.uk',
+  'bluewin.ch',
+  'skynet.be',
+  'sympatico.ca',
+  'windstream.net',
+  'mac.com',
+  'centurytel.net',
+  'chello.nl',
+  'live.ca',
+  'aim.com',
+  'bigpond.net.au',
+  'protonmail.com',
+  'proton.me',
+  'zoho.com',
+];
+
+/**
+ *  Copied from zod {@link https://github.com/colinhacks/zod/blob/0df5f6946ef7137be710767f06ff0c05e7dd9b47/packages/zod/src/v3/types.ts#L617C1-L617C105}
+ **/
+const emailRegex =
+  /(?!\.)(?!.*\.\.)(?<username>[A-Z0-9_'+\-.]*)[A-Z0-9_+-]@(?<domain>[A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}/i;
+
+const extractEmail = (data: string) => {
+  const match = emailRegex.exec(data);
+
+  return match ? match[0] : null;
+};
+
+const removeSubDomains = (domain: string) => {
+  const parts = domain.split('.');
+  return [parts.at(-2), parts.at(-1)].join('.');
+};
+
+type ShouldAnalyzeEmailParams = {
+  sender: string;
+  receiver: string;
+};
+
+export const shouldAnalyzeEmail = ({ sender, receiver }: ShouldAnalyzeEmailParams) => {
+  const senderEmail = extractEmail(sender);
+  const receiverEmail = extractEmail(receiver);
+
+  if (!senderEmail || !receiverEmail) {
+    return false;
+  }
+
+  const [, senderEmailDomain] = senderEmail.split('@') as [string, string];
+  const [, receiverEmailDomain] = receiverEmail.split('@') as [string, string];
+
+  if (PERSONAL_EMAIL_DOMAINS.includes(senderEmailDomain)) {
+    return false;
+  }
+
+  if (removeSubDomains(senderEmailDomain) === removeSubDomains(receiverEmailDomain)) {
+    return false;
+  }
+
+  return true;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './crypto';
+export * from './email-scanning';


### PR DESCRIPTION
## Description

- add common email-scanning utils to pre-filter email
- implement logic pre-filter in outlook & gmail

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests to cover the new feature or fixes.
