### PR TITLE
fix: check permissions before uninstallation google integration

### DIFF
--- a/apps/gmail/src/inngest/functions/common/remove-organisation.test.ts
+++ b/apps/gmail/src/inngest/functions/common/remove-organisation.test.ts
@@ -1,8 +1,10 @@
-import { expect, test, describe } from 'vitest';
+import { expect, test, describe, vi } from 'vitest';
 import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
+import { eq } from 'drizzle-orm';
 import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import { env } from '@/common/env/server';
+import * as googleClientsModule from '@/connectors/google/clients';
 import { removeOrganisation } from './remove-organisation';
 
 const setup = createInngestFunctionMock(
@@ -13,6 +15,11 @@ const setup = createInngestFunctionMock(
 describe('remove-organisation', () => {
   test('should delete organisation and set connection status error successfully ', async () => {
     const elba = spyOnElba();
+
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(googleClientsModule, 'getGoogleServiceAccountClient').mockResolvedValue({
+      authorize: vi.fn().mockRejectedValue(new Error()),
+    });
 
     await db.insert(organisationsTable).values([
       {
@@ -29,7 +36,10 @@ describe('remove-organisation', () => {
       },
     ]);
 
-    const [result] = setup({ organisationId: '00000000-0000-0000-0000-000000000000' });
+    const [result] = setup({
+      organisationId: '00000000-0000-0000-0000-000000000000',
+      inngestRunId: 'inngest-run-id',
+    });
 
     await expect(result).resolves.toStrictEqual({ status: 'deleted' });
 
@@ -57,5 +67,40 @@ describe('remove-organisation', () => {
     const elbaInstance = elba.mock.results[0]?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ errorType: 'unauthorized' });
+  });
+
+  test('should ignore when the client is still authorized ', async () => {
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(googleClientsModule, 'getGoogleServiceAccountClient').mockResolvedValue({
+      authorize: vi.fn().mockResolvedValue(null),
+    });
+    const elba = spyOnElba();
+
+    await db.insert(organisationsTable).values([
+      {
+        googleAdminEmail: 'admin@org1.local',
+        googleCustomerId: 'google-customer-id-1',
+        id: '00000000-0000-0000-0000-000000000000',
+        region: 'eu',
+      },
+    ]);
+
+    const [result] = setup({
+      organisationId: '00000000-0000-0000-0000-000000000000',
+      inngestRunId: 'inngest-run-id',
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      status: 'ignored',
+      message: 'Client is still authorized',
+    });
+
+    const [organisation] = await db
+      .select()
+      .from(organisationsTable)
+      .where(eq(organisationsTable.id, '00000000-0000-0000-0000-000000000000'));
+    expect(organisation).toBeDefined();
+
+    expect(elba).toBeCalledTimes(0);
   });
 });

--- a/apps/gmail/src/inngest/middlewares/gmail-unauthorized-middleware.test.ts
+++ b/apps/gmail/src/inngest/middlewares/gmail-unauthorized-middleware.test.ts
@@ -11,7 +11,7 @@ describe('gmail-unauthorized-middleware', () => {
       // @ts-expect-error -- this is a mock
       .init({ client: { send } })
       // @ts-expect-error -- this is a mock
-      .onFunctionRun({ fn: { name: 'foo' }, ctx: { event: { data: {} } } })
+      .onFunctionRun({ fn: { name: 'foo' }, ctx: { runId: 'run-id', event: { data: {} } } })
       .transformOutput({
         result: {},
       });
@@ -28,7 +28,7 @@ describe('gmail-unauthorized-middleware', () => {
       // @ts-expect-error -- this is a mock
       .init({ client: { send } })
       // @ts-expect-error -- this is a mock
-      .onFunctionRun({ fn: { name: 'foo' }, ctx: { event: { data: {} } } })
+      .onFunctionRun({ fn: { name: 'foo' }, ctx: { runId: 'run-id', event: { data: {} } } })
       .transformOutput({
         result: {
           error: new Error('test'),
@@ -52,7 +52,7 @@ describe('gmail-unauthorized-middleware', () => {
         // @ts-expect-error -- this is a mock
         fn: { name: 'foo' },
         // @ts-expect-error -- this is a mock
-        ctx: { event: { data: { organisationId: 'org-id' } } },
+        ctx: { runId: 'run-id', event: { data: { organisationId: 'org-id' } } },
       })
       .transformOutput({
         result: {
@@ -74,6 +74,7 @@ describe('gmail-unauthorized-middleware', () => {
       name: 'gmail/common.remove_organisation.requested',
       data: {
         organisationId: 'org-id',
+        inngestRunId: 'run-id',
       },
     });
   });

--- a/apps/gmail/src/inngest/middlewares/gmail-unauthorized-middleware.ts
+++ b/apps/gmail/src/inngest/middlewares/gmail-unauthorized-middleware.ts
@@ -8,6 +8,7 @@ export const gmailUnauthorizedMiddleware = new InngestMiddleware({
       onFunctionRun: ({
         fn,
         ctx: {
+          runId,
           event: { data },
         },
       }) => {
@@ -23,7 +24,7 @@ export const gmailUnauthorizedMiddleware = new InngestMiddleware({
               if (typeof organisationId === 'string') {
                 await client.send({
                   name: 'gmail/common.remove_organisation.requested',
-                  data: { organisationId },
+                  data: { organisationId, inngestRunId: runId },
                 });
               }
 

--- a/apps/google/src/inngest/functions/common/remove-organisation.test.ts
+++ b/apps/google/src/inngest/functions/common/remove-organisation.test.ts
@@ -1,8 +1,10 @@
-import { expect, test, describe } from 'vitest';
+import { expect, test, describe, vi } from 'vitest';
 import { createInngestFunctionMock, spyOnElba } from '@elba-security/test-utils';
+import { eq } from 'drizzle-orm';
 import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import { env } from '@/common/env/server';
+import * as googleClientsModule from '@/connectors/google/clients';
 import { removeOrganisation } from './remove-organisation';
 
 const setup = createInngestFunctionMock(
@@ -13,6 +15,11 @@ const setup = createInngestFunctionMock(
 describe('remove-organisation', () => {
   test('should delete organisation and set connection status error successfully ', async () => {
     const elba = spyOnElba();
+
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(googleClientsModule, 'getGoogleServiceAccountClient').mockResolvedValue({
+      authorize: vi.fn().mockRejectedValue(new Error()),
+    });
 
     await db.insert(organisationsTable).values([
       {
@@ -29,7 +36,10 @@ describe('remove-organisation', () => {
       },
     ]);
 
-    const [result] = setup({ organisationId: '00000000-0000-0000-0000-000000000000' });
+    const [result] = setup({
+      organisationId: '00000000-0000-0000-0000-000000000000',
+      inngestRunId: 'inngest-run-id',
+    });
 
     await expect(result).resolves.toStrictEqual({ status: 'deleted' });
 
@@ -56,5 +66,40 @@ describe('remove-organisation', () => {
     const elbaInstance = elba.mock.results[0]?.value;
     expect(elbaInstance?.connectionStatus.update).toBeCalledTimes(1);
     expect(elbaInstance?.connectionStatus.update).toBeCalledWith({ errorType: 'unauthorized' });
+  });
+
+  test('should ignore when the client is still authorized ', async () => {
+    // @ts-expect-error -- this is a mock
+    vi.spyOn(googleClientsModule, 'getGoogleServiceAccountClient').mockResolvedValue({
+      authorize: vi.fn().mockResolvedValue(null),
+    });
+    const elba = spyOnElba();
+
+    await db.insert(organisationsTable).values([
+      {
+        googleAdminEmail: 'admin@org1.local',
+        googleCustomerId: 'google-customer-id-1',
+        id: '00000000-0000-0000-0000-000000000000',
+        region: 'eu',
+      },
+    ]);
+
+    const [result] = setup({
+      organisationId: '00000000-0000-0000-0000-000000000000',
+      inngestRunId: 'inngest-run-id',
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      status: 'ignored',
+      message: 'Client is still authorized',
+    });
+
+    const [organisation] = await db
+      .select()
+      .from(organisationsTable)
+      .where(eq(organisationsTable.id, '00000000-0000-0000-0000-000000000000'));
+    expect(organisation).toBeDefined();
+
+    expect(elba).toBeCalledTimes(0);
   });
 });

--- a/apps/google/src/inngest/functions/common/remove-organisation.ts
+++ b/apps/google/src/inngest/functions/common/remove-organisation.ts
@@ -3,6 +3,7 @@ import { db } from '@/database/client';
 import { organisationsTable } from '@/database/schema';
 import { inngest } from '@/inngest/client';
 import { getElbaClient } from '@/connectors/elba/client';
+import { getGoogleServiceAccountClient } from '@/connectors/google/clients';
 
 export type RemoveOrganisationEvents = {
   'google/common.remove_organisation.requested': RemoveOrganisationRequested;
@@ -11,6 +12,7 @@ export type RemoveOrganisationEvents = {
 type RemoveOrganisationRequested = {
   data: {
     organisationId: string;
+    inngestRunId: string;
   };
 };
 
@@ -28,12 +30,44 @@ export const removeOrganisation = inngest.createFunction(
   { event: 'google/common.remove_organisation.requested' },
   async ({
     event: {
-      data: { organisationId },
+      data: { organisationId, inngestRunId },
     },
     step,
     logger,
   }) => {
-    const [organisation] = await step.run('delete-organisation', () => {
+    const [organisation] = await step.run('get-organisation', () =>
+      db
+        .select({
+          googleAdminEmail: organisationsTable.googleAdminEmail,
+        })
+        .from(organisationsTable)
+        .where(eq(organisationsTable.id, organisationId))
+    );
+
+    if (!organisation) {
+      return { status: 'deleted' };
+    }
+
+    const isAuthorized = await step.run('check-client-authorization', async () => {
+      const serviceAccount = await getGoogleServiceAccountClient(organisation.googleAdminEmail);
+      try {
+        await serviceAccount.authorize();
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    if (isAuthorized) {
+      logger.warn('Client is still authorized despite an uninstallation request', {
+        organisationId,
+        inngestRunId,
+      });
+
+      return { status: 'ignored', message: 'Client is still authorized' };
+    }
+
+    const [deletedOrganisation] = await step.run('delete-organisation', () => {
       return db
         .delete(organisationsTable)
         .where(eq(organisationsTable.id, organisationId))
@@ -42,9 +76,12 @@ export const removeOrganisation = inngest.createFunction(
         });
     });
 
-    if (organisation) {
-      logger.info('Google organisation deleted', { organisationId, region: organisation.region });
-      const elba = getElbaClient({ organisationId, region: organisation.region });
+    if (deletedOrganisation) {
+      logger.info('Google organisation deleted', {
+        organisationId,
+        region: deletedOrganisation.region,
+      });
+      const elba = getElbaClient({ organisationId, region: deletedOrganisation.region });
       await elba.connectionStatus.update({ errorType: 'unauthorized' });
     }
 

--- a/apps/google/src/inngest/middlewares/google-unauthorized-middleware.test.ts
+++ b/apps/google/src/inngest/middlewares/google-unauthorized-middleware.test.ts
@@ -11,7 +11,7 @@ describe('google-unauthorized-middleware', () => {
       // @ts-expect-error -- this is a mock
       .init({ client: { send } })
       // @ts-expect-error -- this is a mock
-      .onFunctionRun({ fn: { name: 'foo' }, ctx: { event: { data: {} } } })
+      .onFunctionRun({ fn: { name: 'foo' }, ctx: { runId: 'run-id', event: { data: {} } } })
       .transformOutput({
         result: {},
       });
@@ -28,7 +28,7 @@ describe('google-unauthorized-middleware', () => {
       // @ts-expect-error -- this is a mock
       .init({ client: { send } })
       // @ts-expect-error -- this is a mock
-      .onFunctionRun({ fn: { name: 'foo' }, ctx: { event: { data: {} } } })
+      .onFunctionRun({ fn: { name: 'foo' }, ctx: { runId: 'run-id', event: { data: {} } } })
       .transformOutput({
         result: {
           error: new Error('test'),
@@ -52,7 +52,7 @@ describe('google-unauthorized-middleware', () => {
         // @ts-expect-error -- this is a mock
         fn: { name: 'foo' },
         // @ts-expect-error -- this is a mock
-        ctx: { event: { data: { organisationId: 'org-id' } } },
+        ctx: { runId: 'run-id', event: { data: { organisationId: 'org-id' } } },
       })
       .transformOutput({
         result: {
@@ -74,6 +74,7 @@ describe('google-unauthorized-middleware', () => {
       name: 'google/common.remove_organisation.requested',
       data: {
         organisationId: 'org-id',
+        inngestRunId: 'run-id',
       },
     });
   });

--- a/apps/google/src/inngest/middlewares/google-unauthorized-middleware.ts
+++ b/apps/google/src/inngest/middlewares/google-unauthorized-middleware.ts
@@ -8,6 +8,7 @@ export const googleUnauthorizedMiddleware = new InngestMiddleware({
       onFunctionRun: ({
         fn,
         ctx: {
+          runId,
           event: { data },
         },
       }) => {
@@ -23,7 +24,7 @@ export const googleUnauthorizedMiddleware = new InngestMiddleware({
               if (typeof organisationId === 'string') {
                 await client.send({
                   name: 'google/common.remove_organisation.requested',
-                  data: { organisationId },
+                  data: { organisationId, inngestRunId: runId },
                 });
               }
 


### PR DESCRIPTION
## Description

For google & gmail integrations: 
- check permissions before removing organisation from db 

## Additional Notes

Add any other context or screenshots about the feature request here.

## Checklist:

Before you create this PR, confirm all the requirements listed below by checking the checkboxes like this (`[x]`).

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests to cover the new feature or fixes.
